### PR TITLE
GH-1: Add a master switch to hide all AI features

### DIFF
--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -303,6 +303,10 @@ final class SearchViewModel: ObservableObject {
     @Published var isEditingSnippet = false
     @Published var editingSnippet: SnippetItem?
 
+    // AI master switch (config: ai_enabled). When false, all AI surfaces
+    // are hidden from the launcher.
+    @Published var aiEnabled: Bool = true
+
     // AI Commands state
     @Published var aiCommands: [AICommand] = []
     @Published var aiCommandSelectedIndex: Int = 0
@@ -539,40 +543,43 @@ final class SearchViewModel: ObservableObject {
         var commandResults: [SearchResult] = []
         let q = query.lowercased()
 
-        // AI commands (built-in + custom) — fuzzy match
-        let matchingAICommands = AICommand.loadAll().filter { cmd in
-            fuzzyMatch(q, cmd.name)
-        }
-        let rankedAICommands = matchingAICommands.sorted { a, b in
-            self.commandRanking(for: a.name) > self.commandRanking(for: b.name)
-        }
-        for cmd in rankedAICommands.prefix(6) {
-            let command = cmd
-            let cmdScore = fuzzyScore(q, command.name) + self.commandRanking(for: command.name)
-            var result = SearchResult(
-                title: command.name,
-                subtitle: "AI Command",
-                icon: nil,
-                systemIcon: command.icon,
-                score: cmdScore
-            ) { [weak self] in
-                self?.incrementCommandRanking(command.name)
-                self?.executeAICommand(command)
+        // AI commands (built-in + custom) — fuzzy match. Hidden entirely when
+        // the AI master switch is off.
+        if aiEnabled {
+            let matchingAICommands = AICommand.loadAll().filter { cmd in
+                fuzzyMatch(q, cmd.name)
             }
-            result.actions = aiCommandActions(for: command)
-            commandResults.append(result)
-        }
+            let rankedAICommands = matchingAICommands.sorted { a, b in
+                self.commandRanking(for: a.name) > self.commandRanking(for: b.name)
+            }
+            for cmd in rankedAICommands.prefix(6) {
+                let command = cmd
+                let cmdScore = fuzzyScore(q, command.name) + self.commandRanking(for: command.name)
+                var result = SearchResult(
+                    title: command.name,
+                    subtitle: "AI Command",
+                    icon: nil,
+                    systemIcon: command.icon,
+                    score: cmdScore
+                ) { [weak self] in
+                    self?.incrementCommandRanking(command.name)
+                    self?.executeAICommand(command)
+                }
+                result.actions = aiCommandActions(for: command)
+                commandResults.append(result)
+            }
 
-        if fuzzyMatch(q, "ai commands") || fuzzyMatch(q, "manage ai commands") {
-            commandResults.append(SearchResult(
-                title: "AI Commands",
-                subtitle: "Manage AI Commands",
-                icon: nil,
-                systemIcon: "sparkle",
-                score: fuzzyScore(q, "AI Commands")
-            ) { [weak self] in
-                self?.goToAICommands()
-            })
+            if fuzzyMatch(q, "ai commands") || fuzzyMatch(q, "manage ai commands") {
+                commandResults.append(SearchResult(
+                    title: "AI Commands",
+                    subtitle: "Manage AI Commands",
+                    icon: nil,
+                    systemIcon: "sparkle",
+                    score: fuzzyScore(q, "AI Commands")
+                ) { [weak self] in
+                    self?.goToAICommands()
+                })
+            }
         }
 
         if fuzzyMatch(q, "snippets") {
@@ -880,6 +887,35 @@ final class SearchViewModel: ObservableObject {
         aiCommandSelectedIndex = 0
     }
 
+    /// Load the `ai_enabled` master switch from config.toml. Called at startup
+    /// and each time the panel opens, so toggling it in Settings takes effect
+    /// the next time the launcher is shown.
+    func loadAIEnabled() {
+        guard let cStr = rc_config_load() else { return }
+        let jsonStr = String(cString: cStr)
+        rc_free_string(cStr)
+        guard let data = jsonStr.data(using: .utf8),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        aiEnabled = config["ai_enabled"] as? Bool ?? true
+        exitAISurfacesIfDisabled()
+    }
+
+    /// When AI is disabled, leave any active AI surface (Claude chat or the AI
+    /// Commands page) so the launcher doesn't reopen mid-conversation or stuck
+    /// on a now-hidden page. No-op while AI is enabled.
+    private func exitAISurfacesIfDisabled() {
+        guard !aiEnabled else { return }
+        if page == .claude {
+            claudeCancel()
+            claudeMessages.removeAll()
+            claudeSessionId = nil
+        }
+        if page == .claude || page == .aiCommands {
+            page = .main
+        }
+        searchMode = .apps
+    }
+
     func saveAICommands() {
         let jsonArray: [[String: Any]] = aiCommands.map { cmd in
             ["name": cmd.name, "icon": cmd.icon, "prompt": cmd.prompt]
@@ -1059,31 +1095,34 @@ final class SearchViewModel: ObservableObject {
             systemIcon: "text.quote"
         ) { [weak self] in self?.goToSnippets() })
 
-        results.append(SearchResult(
-            title: "AI Commands",
-            subtitle: "Command",
-            icon: nil,
-            systemIcon: "sparkle"
-        ) { [weak self] in self?.goToAICommands() })
-
-        // AI Commands — sorted by usage, top 4
-        let aiCommands = AICommand.loadAll()
-        let sorted = aiCommands.sorted { a, b in
-            commandRanking(for: a.name) > commandRanking(for: b.name)
-        }
-        for cmd in sorted.prefix(4) {
-            let command = cmd
-            var result = SearchResult(
-                title: command.name,
-                subtitle: "AI Command",
+        // AI surfaces — hidden entirely when the AI master switch is off.
+        if aiEnabled {
+            results.append(SearchResult(
+                title: "AI Commands",
+                subtitle: "Command",
                 icon: nil,
-                systemIcon: command.icon
-            ) { [weak self] in
-                self?.incrementCommandRanking(command.name)
-                self?.executeAICommand(command)
+                systemIcon: "sparkle"
+            ) { [weak self] in self?.goToAICommands() })
+
+            // AI Commands — sorted by usage, top 4
+            let aiCommands = AICommand.loadAll()
+            let sorted = aiCommands.sorted { a, b in
+                commandRanking(for: a.name) > commandRanking(for: b.name)
             }
-            result.actions = aiCommandActions(for: command)
-            results.append(result)
+            for cmd in sorted.prefix(4) {
+                let command = cmd
+                var result = SearchResult(
+                    title: command.name,
+                    subtitle: "AI Command",
+                    icon: nil,
+                    systemIcon: command.icon
+                ) { [weak self] in
+                    self?.incrementCommandRanking(command.name)
+                    self?.executeAICommand(command)
+                }
+                result.actions = aiCommandActions(for: command)
+                results.append(result)
+            }
         }
 
         return results
@@ -1116,6 +1155,8 @@ final class SearchViewModel: ObservableObject {
     // MARK: - Claude
 
     func toggleSearchMode() {
+        // Claude mode is an AI surface — disabled when the master switch is off.
+        guard aiEnabled else { return }
         if searchMode == .apps {
             searchMode = .claude
             results = []
@@ -1127,6 +1168,7 @@ final class SearchViewModel: ObservableObject {
     }
 
     func claudeAsk() {
+        guard aiEnabled else { return }
         guard !query.isEmpty else { return }
         let prompt = query
 

--- a/AintoApp/Sources/Views/MainView.swift
+++ b/AintoApp/Sources/Views/MainView.swift
@@ -73,18 +73,20 @@ struct MainView: View {
 
                 Spacer()
 
-                // Mode indicator
-                HStack(spacing: 4) {
-                    Text(viewModel.searchMode == .claude ? "Search" : "AI mode")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.tertiary)
-                    Text("Tab")
-                        .font(.system(size: 10, weight: .medium, design: .rounded))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(Color.primary.opacity(0.1))
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                        .foregroundStyle(.tertiary)
+                // Mode indicator — hidden when AI is disabled
+                if viewModel.aiEnabled {
+                    HStack(spacing: 4) {
+                        Text(viewModel.searchMode == .claude ? "Search" : "AI mode")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                        Text("Tab")
+                            .font(.system(size: 10, weight: .medium, design: .rounded))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(Color.primary.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
             .padding(.horizontal, 20)
@@ -155,7 +157,9 @@ struct MainView: View {
                     if !viewModel.query.isEmpty {
                         KeyHint(keys: ["esc"], label: "clear")
                     }
-                    KeyHint(keys: ["Tab"], label: "AI mode")
+                    if viewModel.aiEnabled {
+                        KeyHint(keys: ["Tab"], label: "AI mode")
+                    }
                 }
             }
             .padding(.horizontal, 20)

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -72,6 +72,8 @@ final class SearchPanel: NSPanel {
         viewModel.onGrabSelection = { [weak self] completion in
             self?.grabSelectionFromPreviousApp(completion: completion)
         }
+
+        viewModel.loadAIEnabled()
     }
 
     /// Whether the user has ever positioned the panel manually.
@@ -80,6 +82,9 @@ final class SearchPanel: NSPanel {
     func showPanel() {
         // Remember the currently focused app before showing
         previousApp = NSWorkspace.shared.frontmostApplication
+
+        // Pick up any Settings change to the AI master switch.
+        viewModel.loadAIEnabled()
 
         if !hasUserPosition {
             let screen = NSScreen.screens.first(where: {

--- a/AintoApp/Sources/Views/SettingsView.swift
+++ b/AintoApp/Sources/Views/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     @State private var clipboardImagePath: String = "~/.config/ainto/clipboard"
     @State private var debounceDelay: Int = 300
     @State private var claudeBinary: String = "claude"
-    @State private var claudeEnabled: Bool = true
+    @State private var aiEnabled: Bool = true
     @State private var snippetsEnabled: Bool = true
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var selectedHotkey: String = "⌘ ⇧ Space"
@@ -25,7 +25,7 @@ struct SettingsView: View {
     enum SettingsSection: String, CaseIterable {
         case general = "General"
         case clipboard = "Clipboard"
-        case claude = "Claude Code"
+        case ai = "AI"
         case snippets = "Snippets"
         case data = "Data"
         case about = "About"
@@ -34,7 +34,7 @@ struct SettingsView: View {
             switch self {
             case .general: return "gearshape"
             case .clipboard: return "doc.on.clipboard"
-            case .claude: return "sparkle"
+            case .ai: return "sparkle"
             case .snippets: return "text.quote"
             case .data: return "folder"
             case .about: return "info.circle"
@@ -47,21 +47,12 @@ struct SettingsView: View {
             // Sidebar — darker background
             VStack(spacing: 2) {
                 ForEach(SettingsSection.allCases, id: \.self) { section in
-                    if section == .claude {
-                        SidebarItemCustomIcon(
-                            title: section.rawValue,
-                            icon: { ClaudeIcon(size: 14) },
-                            isSelected: selectedSection == section
-                        )
-                        .onTapGesture { selectedSection = section }
-                    } else {
-                        SidebarItem(
-                            title: section.rawValue,
-                            icon: section.icon,
-                            isSelected: selectedSection == section
-                        )
-                        .onTapGesture { selectedSection = section }
-                    }
+                    SidebarItem(
+                        title: section.rawValue,
+                        icon: section.icon,
+                        isSelected: selectedSection == section
+                    )
+                    .onTapGesture { selectedSection = section }
                 }
                 Spacer()
             }
@@ -76,7 +67,7 @@ struct SettingsView: View {
                     switch selectedSection {
                     case .general: generalSection
                     case .clipboard: clipboardSection
-                    case .claude: claudeSection
+                    case .ai: aiSection
                     case .snippets: snippetsSection
                     case .data: dataSection
                     case .about: aboutSection
@@ -96,7 +87,7 @@ struct SettingsView: View {
         .onChange(of: clipboardMaxImageItems) { _, _ in saveConfig(); applyClipboardLimits() }
         .onChange(of: debounceDelay) { _, _ in saveConfig() }
         .onChange(of: claudeBinary) { _, _ in saveConfig() }
-        .onChange(of: claudeEnabled) { _, _ in saveConfig() }
+        .onChange(of: aiEnabled) { _, _ in saveConfig() }
         .onChange(of: snippetsEnabled) { _, _ in saveConfig() }
         .alert("Reset Rankings", isPresented: $showResetConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -236,24 +227,33 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Claude
+    // MARK: - AI
 
-    private var claudeSection: some View {
+    private var aiSection: some View {
         VStack(alignment: .leading, spacing: 24) {
-            HStack(spacing: 8) {
-                ClaudeIcon(size: 18)
-                Text("Claude Code")
-                    .font(.system(size: 18, weight: .semibold))
-            }
+            SectionHeader(title: "AI", icon: "sparkle")
 
             SettingsCard {
-                VStack(spacing: 16) {
-                    SettingsRow(label: "Enabled") {
-                        Toggle("", isOn: $claudeEnabled).labelsHidden().toggleStyle(.switch)
-                    }
+                SettingsRow(label: "Enabled") {
+                    Toggle("", isOn: $aiEnabled).labelsHidden().toggleStyle(.switch)
+                }
+            }
 
-                    Divider().opacity(0.3)
+            Text("Hides every AI feature in the launcher when off, including AI Commands and Claude mode.")
+                .font(.system(size: 12))
+                .foregroundStyle(.tertiary)
+                .padding(.leading, 4)
 
+            if aiEnabled {
+                // Claude Code subsection
+                HStack(spacing: 6) {
+                    ClaudeIcon(size: 14)
+                    Text("Claude Code")
+                        .font(.system(size: 15, weight: .medium))
+                }
+                .padding(.top, 8)
+
+                SettingsCard {
                     SettingsRow(label: "Binary path") {
                         TextField("claude", text: $claudeBinary)
                             .textFieldStyle(.plain)
@@ -265,48 +265,48 @@ struct SettingsView: View {
                             .frame(maxWidth: 220)
                     }
                 }
-            }
 
-            Text("Press Tab in the launcher to switch to Claude mode.")
-                .font(.system(size: 12))
-                .foregroundStyle(.tertiary)
-                .padding(.leading, 4)
+                Text("Press Tab in the launcher to switch to Claude mode.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 4)
 
-            // AI Commands subsection
-            HStack(spacing: 6) {
-                Image(systemName: "sparkle")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
-                Text("AI Commands")
-                    .font(.system(size: 15, weight: .medium))
-            }
-            .padding(.top, 8)
-
-            SettingsCard {
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("ai-commands.toml")
-                            .font(.system(size: 13))
-                        Text("Add, remove, or modify AI commands")
-                            .font(.system(size: 12))
-                            .foregroundStyle(.tertiary)
-                    }
-                    Spacer()
-                    Button("Edit") {
-                        let _ = rc_ai_commands_load()
-                        let path = ("~/.config/ainto/ai-commands.toml" as NSString).expandingTildeInPath
-                        NSWorkspace.shared.open(URL(fileURLWithPath: path))
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 13))
-                    .foregroundColor(.accentColor)
+                // AI Commands subsection
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkle")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                    Text("AI Commands")
+                        .font(.system(size: 15, weight: .medium))
                 }
-            }
+                .padding(.top, 8)
 
-            Text("Use {selection} as placeholder for selected text in prompts.")
-                .font(.system(size: 12))
-                .foregroundStyle(.tertiary)
-                .padding(.leading, 4)
+                SettingsCard {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("ai-commands.toml")
+                                .font(.system(size: 13))
+                            Text("Add, remove, or modify AI commands")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.tertiary)
+                        }
+                        Spacer()
+                        Button("Edit") {
+                            let _ = rc_ai_commands_load()
+                            let path = ("~/.config/ainto/ai-commands.toml" as NSString).expandingTildeInPath
+                            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 13))
+                        .foregroundColor(.accentColor)
+                    }
+                }
+
+                Text("Use {selection} as placeholder for selected text in prompts.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 4)
+            }
         }
     }
 
@@ -515,7 +515,7 @@ struct SettingsView: View {
         clipboardMaxImageItems = config["clipboard_max_image_items"] as? Int ?? 50
         debounceDelay = config["debounce_delay"] as? Int ?? 300
         claudeBinary = config["claude_binary"] as? String ?? "claude"
-        claudeEnabled = config["claude_enabled"] as? Bool ?? true
+        aiEnabled = config["ai_enabled"] as? Bool ?? true
         snippetsEnabled = config["snippets_enabled"] as? Bool ?? true
         hasLoaded = true
     }
@@ -528,7 +528,7 @@ struct SettingsView: View {
             "search_dirs": ["~"],
             "debounce_delay": debounceDelay,
             "claude_binary": claudeBinary,
-            "claude_enabled": claudeEnabled,
+            "ai_enabled": aiEnabled,
             "snippets_enabled": snippetsEnabled,
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: config),
@@ -612,31 +612,6 @@ struct SidebarItem: View {
             Image(systemName: icon)
                 .font(.system(size: 13))
                 .frame(width: 18)
-            Text(title)
-                .font(.system(size: 14))
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background {
-            if isSelected {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.accentColor.opacity(0.2))
-            }
-        }
-        .foregroundStyle(isSelected ? .primary : .secondary)
-        .contentShape(Rectangle())
-    }
-}
-
-struct SidebarItemCustomIcon<Icon: View>: View {
-    let title: String
-    @ViewBuilder let icon: () -> Icon
-    let isSelected: Bool
-
-    var body: some View {
-        HStack(spacing: 8) {
-            icon().frame(width: 18)
             Text(title)
                 .font(.system(size: 14))
             Spacer()

--- a/ainto-core/src/config.rs
+++ b/ainto-core/src/config.rs
@@ -16,8 +16,10 @@ pub struct Config {
     pub search_dirs: Vec<String>,
     pub debounce_delay: u64,
     pub claude_binary: String,
-    pub claude_enabled: bool,
     pub snippets_enabled: bool,
+    /// Master switch for all AI-related features in the UI.
+    /// When false, the launcher hides every AI surface.
+    pub ai_enabled: bool,
 }
 
 impl Default for Config {
@@ -28,8 +30,8 @@ impl Default for Config {
             search_dirs: vec!["~".to_string()],
             debounce_delay: 300,
             claude_binary: "claude".to_string(),
-            claude_enabled: true,
             snippets_enabled: true,
+            ai_enabled: true,
         }
     }
 }


### PR DESCRIPTION
Refs #1

Adds an `ai_enabled` master switch (Settings → AI) that hides every AI
surface in the launcher — AI Commands, Claude mode, and Claude chat — for
a clean, AI-free experience. Disabling it also exits any active AI surface
so the launcher never reopens mid-conversation.

Replaces the unused `claude_enabled` flag; old configs migrate via serde
defaults.