### PR TITLE
Fixed multiple bugs in snippets

### DIFF
--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -531,7 +531,8 @@ final class SearchViewModel: ObservableObject {
                             icon: nil,
                             systemIcon: "doc.text.fill"
                         ) {
-                            if let cStr = rc_snippet_expand(expansion, nil) {
+                            let clipboardText = NSPasteboard.general.string(forType: .string)
+                            if let cStr = rc_snippet_expand(expansion, clipboardText) {
                                 let expanded = String(cString: cStr)
                                 rc_free_string(cStr)
                                 NSPasteboard.general.clearContents()

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -874,7 +874,8 @@ final class SearchViewModel: ObservableObject {
         guard snippetSelectedIndex < items.count else { return }
         let snippet = items[snippetSelectedIndex]
 
-        if let cStr = rc_snippet_expand(snippet.expansion, nil) {
+        let clipboardText = NSPasteboard.general.string(forType: .string)
+        if let cStr = rc_snippet_expand(snippet.expansion, clipboardText) {
             let expanded = String(cString: cStr)
             rc_free_string(cStr)
             NSPasteboard.general.clearContents()

--- a/AintoApp/Sources/Views/SnippetView.swift
+++ b/AintoApp/Sources/Views/SnippetView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import AintoCore
 
 /// Snippet management sub-page — list + preview/edit.
 struct SnippetView: View {
@@ -210,7 +211,7 @@ struct SnippetPreview: View {
             VStack(spacing: 0) {
                 // Expansion preview
                 ScrollView {
-                    Text(snippet.expansion)
+                    Text(expandedText)
                         .font(.system(size: 13, design: .monospaced))
                         .foregroundColor(.primary)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -265,6 +266,16 @@ struct SnippetPreview: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private var expandedText: String {
+        guard let snippet else { return "" }
+        let clipboardText = NSPasteboard.general.string(forType: .string)
+        guard let cStr = rc_snippet_expand(snippet.expansion, clipboardText) else {
+            return snippet.expansion
+        }
+        defer { rc_free_string(cStr) }
+        return String(cString: cStr)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | **AI** | Press Tab to chat, or select text → run & replace (Fix Grammar, Translate, Summarize, or your own) |
 | **App Search** | Fuzzy search and launch macOS apps instantly |
 | **Clipboard History** | Persistent history with text, image, and file support |
-| **Snippets** | Text expansion in any app with dynamic placeholders (`{date}`, `{clipboard}`) |
+| **Snippets** | Text expansion in any app with dynamic placeholders (`{date}`, `{clipboard}`, `{time}`, `{uuid}`) |
 
 > **AI & billing:** Ainto runs the Claude Code CLI on your Mac (`claude -p`), so AI usage is billed to your own Claude account — Ainto stores no API key and never charges you. See [how Claude meters Agent SDK / `claude -p` usage](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,7 +35,7 @@
 | **AI** | 按 Tab 開始對話，或選取文字後執行並取代（修正文法、翻譯、摘要，或自訂指令） |
 | **應用程式搜尋** | 模糊搜尋並即時啟動 macOS 應用程式 |
 | **剪貼簿歷史** | 持久化的歷史記錄，支援文字、圖片與檔案 |
-| **文字片段** | 在任何 app 中展開文字，支援動態佔位符（`{date}`、`{clipboard}`, `{time}`, `{uuid}`） |
+| **文字片段** | 在任何 app 中展開文字，支援動態佔位符（`{date}`、`{clipboard}`、`{time}`、`{uuid}`） |
 
 > **AI 與計費：** Ainto 透過你 Mac 上的 Claude Code（`claude -p`）執行 AI，用量計入你自己的 Claude 帳號。Ainto 不儲存 API key，也不向你收費。計費方式請見 [Claude 對 Agent SDK 與 `claude -p` 用量的說明](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,7 +35,7 @@
 | **AI** | 按 Tab 開始對話，或選取文字後執行並取代（修正文法、翻譯、摘要，或自訂指令） |
 | **應用程式搜尋** | 模糊搜尋並即時啟動 macOS 應用程式 |
 | **剪貼簿歷史** | 持久化的歷史記錄，支援文字、圖片與檔案 |
-| **文字片段** | 在任何 app 中展開文字，支援動態佔位符（`{date}`、`{clipboard}`） |
+| **文字片段** | 在任何 app 中展開文字，支援動態佔位符（`{date}`、`{clipboard}`, `{time}`, `{uuid}`） |
 
 > **AI 與計費：** Ainto 透過你 Mac 上的 Claude Code（`claude -p`）執行 AI，用量計入你自己的 Claude 帳號。Ainto 不儲存 API key，也不向你收費。計費方式請見 [Claude 對 Agent SDK 與 `claude -p` 用量的說明](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)。
 

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -76,9 +76,8 @@ pub fn resolve_placeholders(text: &str, clipboard_text: Option<&str>) -> String 
         .unwrap_or_default()
         .as_secs();
 
-    // Simple date/time formatting without chrono dependency
-    // Unix timestamp → date components
-    let (year, month, day, hour, min, sec) = unix_to_datetime(now as i64);
+    // Use the host timezone so snippets match the user's macOS clock.
+    let (year, month, day, hour, min, sec) = local_datetime(now as i64);
 
     let date_str = format!("{year:04}-{month:02}-{day:02}");
     let time_str = format!("{hour:02}:{min:02}:{sec:02}");
@@ -89,8 +88,33 @@ pub fn resolve_placeholders(text: &str, clipboard_text: Option<&str>) -> String 
         .replace("{uuid}", &uuid::Uuid::new_v4().to_string())
 }
 
-/// Minimal unix timestamp to date/time conversion (UTC).
-fn unix_to_datetime(timestamp: i64) -> (i32, u32, u32, u32, u32, u32) {
+/// Convert a Unix timestamp to local date/time without adding a date-time crate.
+#[cfg(target_os = "macos")]
+fn local_datetime(timestamp: i64) -> (i32, u32, u32, u32, u32, u32) {
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::zeroed();
+    // `localtime_r` writes a fully initialized `tm` on success.
+    let result = unsafe { libc::localtime_r(&timestamp, tm.as_mut_ptr()) };
+    if result.is_null() {
+        return unix_to_datetime_utc(timestamp);
+    }
+    let tm = unsafe { tm.assume_init() };
+    (
+        tm.tm_year + 1900,
+        tm.tm_mon as u32 + 1,
+        tm.tm_mday as u32,
+        tm.tm_hour as u32,
+        tm.tm_min as u32,
+        tm.tm_sec as u32,
+    )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn local_datetime(timestamp: i64) -> (i32, u32, u32, u32, u32, u32) {
+    unix_to_datetime_utc(timestamp)
+}
+
+/// Minimal Unix timestamp conversion used as a portable fallback.
+fn unix_to_datetime_utc(timestamp: i64) -> (i32, u32, u32, u32, u32, u32) {
     let secs_per_day: i64 = 86400;
     let days = timestamp / secs_per_day;
     let remaining_secs = (timestamp % secs_per_day) as u32;
@@ -150,6 +174,23 @@ mod tests {
         // Should be a valid date format
         assert!(result.len() == 10); // yyyy-MM-dd
         assert!(result.contains('-'));
+    }
+
+    #[test]
+    fn test_resolve_time_and_uuid_placeholders() {
+        let result = resolve_placeholders("{time} {uuid}", None);
+        let mut parts = result.split(' ');
+        let time = parts.next().unwrap();
+        let uuid = parts.next().unwrap();
+        assert_eq!(time.len(), 8);
+        assert!(time.as_bytes()[2] == b':' && time.as_bytes()[5] == b':');
+        assert_eq!(uuid.len(), 36);
+        assert_eq!(uuid.chars().filter(|c| *c == '-').count(), 4);
+    }
+
+    #[test]
+    fn test_missing_clipboard_resolves_to_empty() {
+        assert_eq!(resolve_placeholders("before{clipboard}after", None), "beforeafter");
     }
 
     #[test]

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -92,6 +92,12 @@ pub fn resolve_placeholders(text: &str, clipboard_text: Option<&str>) -> String 
 #[cfg(target_os = "macos")]
 fn local_datetime(timestamp: i64) -> (i32, u32, u32, u32, u32, u32) {
     let mut tm = std::mem::MaybeUninit::<libc::tm>::zeroed();
+    // `localtime_r` is not required to refresh the process timezone state.
+    // Refresh it explicitly so runtime timezone changes are observed.
+    unsafe extern "C" {
+        fn tzset();
+    }
+    unsafe { tzset() };
     // `localtime_r` writes a fully initialized `tm` on success.
     let result = unsafe { libc::localtime_r(&timestamp, tm.as_mut_ptr()) };
     if result.is_null() {


### PR DESCRIPTION
1. Fix a bug where panel Enter's {clipboard} was a null character.
    `SearchViewModel.expandSelectedSnippet` now reads `NSPasteboard.general` and passes it to `rc_snippet_expand`, and panel paste and global keyword expand behave the same way.

2. {date}, {time} use macOS current timezone
    Rust kernel uses macOS `localtime_r` to fallback to UTC on failure; no more fixed UTC expansion.

3. Preview panel displays expanded results
    `SnippetPreview` now calculates the preview from the same FFI expand function passed to the current clipboard, so it displays the actual date, time, UUID, and clipboard contents instead of the original template.


