### PR TITLE
Add snippet shell mode

### DIFF
--- a/AintoApp/AintoCoreBridge/ainto_core.h
+++ b/AintoApp/AintoCoreBridge/ainto_core.h
@@ -97,6 +97,10 @@ int32_t rc_snippets_save(const char* json);
 /// clipboard_text can be NULL
 const char* rc_snippet_expand(const char* expansion_text, const char* clipboard_text);
 
+/// Execute a shell snippet and return trimmed stdout; returns NULL on failure.
+/// clipboard_text can be NULL.
+const char* rc_snippet_execute(const char* command, const char* clipboard_text);
+
 // ============================================================
 // AI Commands
 // ============================================================

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -274,9 +274,11 @@ struct SnippetItem: Identifiable {
     var name: String
     var keyword: String
     var expansion: String
+    var mode: String
+    var command: String
 
     static func new() -> SnippetItem {
-        SnippetItem(id: UUID().uuidString, name: "", keyword: "", expansion: "")
+        SnippetItem(id: UUID().uuidString, name: "", keyword: "", expansion: "", mode: "text", command: "")
     }
 }
 
@@ -522,16 +524,27 @@ final class SearchViewModel: ObservableObject {
                     }
                     .prefix(5)
                     .map { snippet in
+                        let id = snippet["id"] as? String ?? UUID().uuidString
                         let name = snippet["name"] as? String ?? ""
                         let keyword = snippet["keyword"] as? String ?? ""
                         let expansion = snippet["expansion"] as? String ?? ""
+                        let mode = snippet["mode"] as? String ?? "text"
+                        let command = snippet["command"] as? String ?? ""
+                        let item = SnippetItem(
+                            id: id,
+                            name: name,
+                            keyword: keyword,
+                            expansion: expansion,
+                            mode: mode,
+                            command: command
+                        )
                         return SearchResult(
                             title: name,
                             subtitle: "Snippet: \(keyword)",
                             icon: nil,
                             systemIcon: "doc.text.fill"
                         ) { [weak self] in
-                            self?.expandAndPasteSnippet(expansion)
+                            self?.expandAndPasteSnippet(item)
                         }
                     }
             }
@@ -801,7 +814,9 @@ final class SearchViewModel: ObservableObject {
                 id: entry["id"] as? String ?? UUID().uuidString,
                 name: entry["name"] as? String ?? "",
                 keyword: entry["keyword"] as? String ?? "",
-                expansion: entry["expansion"] as? String ?? ""
+                expansion: entry["expansion"] as? String ?? "",
+                mode: entry["mode"] as? String ?? "text",
+                command: entry["command"] as? String ?? ""
             )
         }
         snippetSelectedIndex = 0
@@ -809,7 +824,8 @@ final class SearchViewModel: ObservableObject {
 
     func saveSnippets() {
         let jsonArray: [[String: Any]] = snippets.map { s in
-            ["id": s.id, "name": s.name, "keyword": s.keyword, "expansion": s.expansion]
+            ["id": s.id, "name": s.name, "keyword": s.keyword, "expansion": s.expansion,
+             "mode": s.mode, "command": s.command]
         }
         guard let data = try? JSONSerialization.data(withJSONObject: jsonArray),
               let jsonStr = String(data: data, encoding: .utf8) else { return }
@@ -867,16 +883,34 @@ final class SearchViewModel: ObservableObject {
     func expandSelectedSnippet() {
         let items = filteredSnippets
         guard snippetSelectedIndex < items.count else { return }
-        expandAndPasteSnippet(items[snippetSelectedIndex].expansion)
+        expandAndPasteSnippet(items[snippetSelectedIndex])
     }
 
     /// Expand a snippet's placeholders, put the result on the pasteboard,
     /// and paste it into the frontmost app.
-    private func expandAndPasteSnippet(_ expansion: String) {
+    private func expandAndPasteSnippet(_ snippet: SnippetItem) {
         let clipboardText = NSPasteboard.general.string(forType: .string)
-        guard let cStr = rc_snippet_expand(expansion, clipboardText) else { return }
-        let expanded = String(cString: cStr)
-        rc_free_string(cStr)
+        if snippet.mode.caseInsensitiveCompare("shell") == .orderedSame {
+            let command = snippet.command
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                guard let cStr = rc_snippet_execute(command, clipboardText) else { return }
+                let expanded = String(cString: cStr)
+                rc_free_string(cStr)
+                DispatchQueue.main.async {
+                    self?.pasteExpandedSnippet(expanded)
+                }
+            }
+            return
+        }
+
+        if let cStr = rc_snippet_expand(snippet.expansion, clipboardText) {
+            let expanded = String(cString: cStr)
+            rc_free_string(cStr)
+            pasteExpandedSnippet(expanded)
+        }
+    }
+
+    private func pasteExpandedSnippet(_ expanded: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(expanded, forType: .string)
         onPasteAndHide?()

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -530,21 +530,13 @@ final class SearchViewModel: ObservableObject {
                         let expansion = snippet["expansion"] as? String ?? ""
                         let mode = snippet["mode"] as? String ?? "text"
                         let command = snippet["command"] as? String ?? ""
-                        let item = SnippetItem(
-                            id: id,
-                            name: name,
-                            keyword: keyword,
-                            expansion: expansion,
-                            mode: mode,
-                            command: command
-                        )
                         return SearchResult(
                             title: name,
                             subtitle: "Snippet: \(keyword)",
                             icon: nil,
                             systemIcon: "doc.text.fill"
                         ) { [weak self] in
-                            self?.expandAndPasteSnippet(item)
+                            self?.executeSnippet(mode: mode, expansion: expansion, command: command)
                         }
                     }
             }
@@ -883,15 +875,14 @@ final class SearchViewModel: ObservableObject {
     func expandSelectedSnippet() {
         let items = filteredSnippets
         guard snippetSelectedIndex < items.count else { return }
-        expandAndPasteSnippet(items[snippetSelectedIndex])
+        let snippet = items[snippetSelectedIndex]
+        executeSnippet(mode: snippet.mode, expansion: snippet.expansion, command: snippet.command)
     }
 
-    /// Expand a snippet's placeholders, put the result on the pasteboard,
-    /// and paste it into the frontmost app.
-    private func expandAndPasteSnippet(_ snippet: SnippetItem) {
-        let clipboardText = NSPasteboard.general.string(forType: .string)
-        if snippet.mode.caseInsensitiveCompare("shell") == .orderedSame {
-            let command = snippet.command
+    private func executeSnippet(mode: String, expansion: String, command: String) {
+        if mode.caseInsensitiveCompare("shell") == .orderedSame {
+            guard !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            let clipboardText = NSPasteboard.general.string(forType: .string)
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let cStr = rc_snippet_execute(command, clipboardText) else { return }
                 let expanded = String(cString: cStr)
@@ -903,7 +894,8 @@ final class SearchViewModel: ObservableObject {
             return
         }
 
-        if let cStr = rc_snippet_expand(snippet.expansion, clipboardText) {
+        let clipboardText = NSPasteboard.general.string(forType: .string)
+        if let cStr = rc_snippet_expand(expansion, clipboardText) {
             let expanded = String(cString: cStr)
             rc_free_string(cStr)
             pasteExpandedSnippet(expanded)

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -289,7 +289,13 @@ final class SearchViewModel: ObservableObject {
     @Published var results: [SearchResult] = []
     @Published var selectedIndex: Int = 0
     @Published var shouldSelectAll = false
-    @Published var page: LauncherPage = .main
+    @Published var page: LauncherPage = .main {
+        didSet {
+            if page != oldValue {
+                invalidatePendingShellExecution()
+            }
+        }
+    }
     @Published var searchMode: SearchMode = .apps
 
     // Claude state
@@ -304,6 +310,7 @@ final class SearchViewModel: ObservableObject {
     @Published var snippetFilter: String = ""
     @Published var isEditingSnippet = false
     @Published var editingSnippet: SnippetItem?
+    private var shellExecutionGeneration: UInt64 = 0
 
     // AI master switch (config: ai_enabled). When false, all AI surfaces
     // are hidden from the launcher.
@@ -879,7 +886,19 @@ final class SearchViewModel: ObservableObject {
         executeSnippet(mode: snippet.mode, expansion: snippet.expansion, command: snippet.command)
     }
 
+    /// Invalidate shell work that belongs to an older launcher interaction.
+    /// This is called when the panel is reopened or when navigation changes.
+    func invalidatePendingShellExecution() {
+        shellExecutionGeneration &+= 1
+    }
+
+    private func beginSnippetExecution() -> UInt64 {
+        shellExecutionGeneration &+= 1
+        return shellExecutionGeneration
+    }
+
     private func executeSnippet(mode: String, expansion: String, command: String) {
+        let executionToken = beginSnippetExecution()
         if mode.caseInsensitiveCompare("shell") == .orderedSame {
             guard !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             let clipboardText = NSPasteboard.general.string(forType: .string)
@@ -888,7 +907,8 @@ final class SearchViewModel: ObservableObject {
                 let expanded = String(cString: cStr)
                 rc_free_string(cStr)
                 DispatchQueue.main.async {
-                    self?.pasteExpandedSnippet(expanded)
+                    guard let self, self.shellExecutionGeneration == executionToken else { return }
+                    self.pasteExpandedSnippet(expanded)
                 }
             }
             return

--- a/AintoApp/Sources/Services/TextExpander.swift
+++ b/AintoApp/Sources/Services/TextExpander.swift
@@ -27,6 +27,7 @@ final class TextExpander {
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var workspaceObserver: NSObjectProtocol?
 
     /// Lock protecting all static mutable state accessed from CGEvent tap thread.
     private static let lock = NSLock()
@@ -62,6 +63,17 @@ final class TextExpander {
 
         loadSnippets()
         installEventTap()
+        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // A shell replacement belongs to the app that received its
+            // trigger. Activation of another app invalidates that target.
+            Task { @MainActor in
+                Self.cancelPendingShellReplacementForTargetChange()
+            }
+        }
     }
 
     func stop() {
@@ -70,6 +82,10 @@ final class TextExpander {
         }
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        if let workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(workspaceObserver)
+            self.workspaceObserver = nil
         }
         eventTap = nil
         runLoopSource = nil
@@ -125,7 +141,11 @@ final class TextExpander {
     // MARK: - CGEvent Tap
 
     private func installEventTap() {
-        let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
+        let eventMask: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue) |
+            (1 << CGEventType.leftMouseDown.rawValue) |
+            (1 << CGEventType.rightMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue)
 
         // The callback must be a C function pointer — use a static method
         let tap = CGEvent.tapCreate(
@@ -161,6 +181,15 @@ final class TextExpander {
             if let tap = sharedEventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }
+            return Unmanaged.passRetained(event)
+        }
+
+        if type == .leftMouseDown || type == .rightMouseDown || type == .otherMouseDown {
+            // Mouse clicks can move the caret without producing a key event,
+            // so they invalidate the target of an in-flight replacement.
+            lock.lock()
+            cancelPendingShellReplacementForTargetChangeLocked()
+            lock.unlock()
             return Unmanaged.passRetained(event)
         }
 
@@ -300,6 +329,22 @@ final class TextExpander {
         pendingShellReplacement = nil
         let restored = pending.bufferPrefix + pending.keyword
         buffer = String(restored.suffix(maxBufferLength))
+    }
+
+    /// Invalidate both the pending replacement and the rolling input context.
+    /// The latter belongs to the previously focused target and must not be
+    /// reused after an app switch or caret movement.
+    private static func cancelPendingShellReplacementForTargetChange() {
+        lock.lock()
+        cancelPendingShellReplacementForTargetChangeLocked()
+        lock.unlock()
+    }
+
+    /// Caller must hold `lock`.
+    private static func cancelPendingShellReplacementForTargetChangeLocked() {
+        pendingShellReplacement = nil
+        buffer = ""
+        lastKeystrokeTime = Date()
     }
 
     /// Check if the buffer ends with any snippet keyword.

--- a/AintoApp/Sources/Services/TextExpander.swift
+++ b/AintoApp/Sources/Services/TextExpander.swift
@@ -13,6 +13,12 @@ import AintoCore
 /// - System Settings → Privacy & Security → Input Monitoring
 @MainActor
 final class TextExpander {
+    private struct SnippetDefinition {
+        let mode: String
+        let expansion: String
+        let command: String
+    }
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
@@ -26,7 +32,7 @@ final class TextExpander {
     private static let bufferTimeout: TimeInterval = 10 // clear after 10s inactivity
 
     /// Snippet keyword → expansion mapping.
-    private static var snippetMap: [String: String] = [:]
+    private static var snippetMap: [String: SnippetDefinition] = [:]
 
     /// Trie for efficient keyword matching.
     private static var trie = Trie()
@@ -90,9 +96,13 @@ final class TextExpander {
         Self.trie = Trie()
 
         for entry in entries {
-            guard let keyword = entry["keyword"] as? String, !keyword.isEmpty,
-                  let expansion = entry["expansion"] as? String else { continue }
-            Self.snippetMap[keyword] = expansion
+            guard let keyword = entry["keyword"] as? String, !keyword.isEmpty else { continue }
+            let definition = SnippetDefinition(
+                mode: entry["mode"] as? String ?? "text",
+                expansion: entry["expansion"] as? String ?? "",
+                command: entry["command"] as? String ?? ""
+            )
+            Self.snippetMap[keyword] = definition
             Self.trie.insert(keyword)
         }
         Self.lock.unlock()
@@ -195,14 +205,14 @@ final class TextExpander {
         }
 
         // Check if buffer ends with any snippet keyword
-        if let (keyword, expansion) = findMatch() {
+        if let (keyword, snippet) = findMatch() {
             // Remove the keyword from the buffer
             buffer = String(buffer.dropLast(keyword.count))
             lock.unlock()
 
             // Perform replacement on main thread
             DispatchQueue.main.async {
-                performReplacement(keywordLength: keyword.count, expansion: expansion)
+                performReplacement(keyword: keyword, snippet: snippet)
             }
 
             // Suppress the last keystroke (it's part of the keyword)
@@ -214,27 +224,49 @@ final class TextExpander {
     }
 
     /// Check if the buffer ends with any snippet keyword.
-    private static func findMatch() -> (keyword: String, expansion: String)? {
+    private static func findMatch() -> (keyword: String, snippet: SnippetDefinition)? {
         // Check from longest possible match to shortest
         let maxLen = min(buffer.count, maxBufferLength)
         for len in stride(from: maxLen, through: 1, by: -1) {
             let suffix = String(buffer.suffix(len))
-            if trie.contains(suffix), let expansion = snippetMap[suffix] {
-                // Resolve placeholders
-                var resolved = expansion
-                let clipboardText = NSPasteboard.general.string(forType: .string)
-                if let cStr = rc_snippet_expand(expansion, clipboardText) {
-                    resolved = String(cString: cStr)
-                    rc_free_string(cStr)
-                }
-                return (suffix, resolved)
+            if trie.contains(suffix), let snippet = snippetMap[suffix] {
+                return (suffix, snippet)
             }
         }
         return nil
     }
 
     /// Delete the keyword characters and type the expansion.
-    private static func performReplacement(keywordLength: Int, expansion: String) {
+    private static func performReplacement(keyword: String, snippet: SnippetDefinition) {
+        if snippet.mode.caseInsensitiveCompare("shell") == .orderedSame {
+            let clipboardText = NSPasteboard.general.string(forType: .string)
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let cStr = rc_snippet_execute(snippet.command, clipboardText) else {
+                    // The final trigger character was suppressed; restore the full keyword.
+                    DispatchQueue.main.async {
+                        replaceKeywordAndPaste(keywordLength: keyword.count, text: keyword)
+                    }
+                    return
+                }
+                let output = String(cString: cStr)
+                rc_free_string(cStr)
+                DispatchQueue.main.async {
+                    replaceKeywordAndPaste(keywordLength: keyword.count, text: output)
+                }
+            }
+            return
+        }
+
+        let clipboardText = NSPasteboard.general.string(forType: .string)
+        var resolved = snippet.expansion
+        if let cStr = rc_snippet_expand(snippet.expansion, clipboardText) {
+            resolved = String(cString: cStr)
+            rc_free_string(cStr)
+        }
+        replaceKeywordAndPaste(keywordLength: keyword.count, text: resolved)
+    }
+
+    private static func replaceKeywordAndPaste(keywordLength: Int, text: String) {
         let source = CGEventSource(stateID: .combinedSessionState)
 
         // Step 1: Send backspace to delete the keyword (minus the last char which was suppressed)
@@ -253,7 +285,7 @@ final class TextExpander {
         let pasteboard = NSPasteboard.general
         let oldContents = pasteboard.string(forType: .string)
         pasteboard.clearContents()
-        pasteboard.setString(expansion, forType: .string)
+        pasteboard.setString(text, forType: .string)
         pasteboard.setData(Data(), forType: NSPasteboard.PasteboardType("org.nspasteboard.TransientType"))
 
         // Simulate Cmd+V

--- a/AintoApp/Sources/Services/TextExpander.swift
+++ b/AintoApp/Sources/Services/TextExpander.swift
@@ -237,10 +237,17 @@ final class TextExpander {
 
         // Check if buffer ends with any snippet keyword
         if let (keyword, snippet) = findMatch() {
+            let isShell = snippet.mode.caseInsensitiveCompare("shell") == .orderedSame
+            if isShell && snippet.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                // Keep the keyword intact when there is no command to run.
+                // Returning the event avoids consuming any part of the input.
+                lock.unlock()
+                return Unmanaged.passRetained(event)
+            }
+
             // Remove the keyword from the buffer
             buffer = String(buffer.dropLast(keyword.count))
 
-            let isShell = snippet.mode.caseInsensitiveCompare("shell") == .orderedSame
             if isShell {
                 nextShellReplacementID &+= 1
                 let replacementID = nextShellReplacementID
@@ -316,6 +323,10 @@ final class TextExpander {
     ) {
         if snippet.mode.caseInsensitiveCompare("shell") == .orderedSame {
             guard let replacementID, hasPendingShellReplacement(replacementID) else { return }
+            guard !snippet.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                cancelPendingShellReplacement(replacementID)
+                return
+            }
             let clipboardText = NSPasteboard.general.string(forType: .string)
             DispatchQueue.global(qos: .userInitiated).async {
                 guard let cStr = rc_snippet_execute(snippet.command, clipboardText) else {

--- a/AintoApp/Sources/Services/TextExpander.swift
+++ b/AintoApp/Sources/Services/TextExpander.swift
@@ -19,6 +19,12 @@ final class TextExpander {
         let command: String
     }
 
+    private struct PendingShellReplacement {
+        let id: UInt64
+        let keyword: String
+        let bufferPrefix: String
+    }
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
@@ -36,6 +42,11 @@ final class TextExpander {
 
     /// Trie for efficient keyword matching.
     private static var trie = Trie()
+
+    /// Shell commands run off the event-tap thread. Keep a token so input
+    /// arriving before completion can cancel the stale replacement safely.
+    private static var nextShellReplacementID: UInt64 = 0
+    private static var pendingShellReplacement: PendingShellReplacement?
 
     // MARK: - Public
 
@@ -62,6 +73,9 @@ final class TextExpander {
         }
         eventTap = nil
         runLoopSource = nil
+        Self.lock.lock()
+        Self.pendingShellReplacement = nil
+        Self.lock.unlock()
     }
 
     /// Reload snippets from disk (call after snippet CRUD).
@@ -156,6 +170,9 @@ final class TextExpander {
 
         // Skip keystroke capture for password managers and secure input fields
         if SecureInput.isActive {
+            lock.lock()
+            cancelPendingShellReplacementLocked()
+            lock.unlock()
             return Unmanaged.passRetained(event)
         }
 
@@ -163,23 +180,38 @@ final class TextExpander {
         let flags = event.flags
         if flags.contains(.maskCommand) || flags.contains(.maskControl) || flags.contains(.maskAlternate) {
             lock.lock()
+            cancelPendingShellReplacementLocked()
             buffer = ""
             lock.unlock()
             return Unmanaged.passRetained(event)
         }
 
         // Get the character
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         var length = 0
         var chars = [UniChar](repeating: 0, count: 4)
         event.keyboardGetUnicodeString(maxStringLength: 4, actualStringLength: &length, unicodeString: &chars)
 
         guard length > 0 else {
+            // Backspace and other non-printing key events still invalidate a
+            // pending shell replacement, so it cannot delete newer input.
+            lock.lock()
+            cancelPendingShellReplacementLocked()
+            if keyCode == 51, !buffer.isEmpty {
+                buffer.removeLast()
+            }
+            lock.unlock()
             return Unmanaged.passRetained(event)
         }
 
         let char = String(utf16CodeUnits: chars, count: length)
 
         lock.lock()
+
+        // The shell trigger's final key is allowed through to the target app.
+        // If the user continues typing before the command completes, retain
+        // the already-typed keyword and abandon the asynchronous replacement.
+        cancelPendingShellReplacementLocked()
 
         // Check for buffer timeout
         let now = Date()
@@ -189,7 +221,6 @@ final class TextExpander {
         lastKeystrokeTime = now
 
         // Handle backspace
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         if keyCode == 51 { // Backspace
             if !buffer.isEmpty {
                 buffer.removeLast()
@@ -208,11 +239,35 @@ final class TextExpander {
         if let (keyword, snippet) = findMatch() {
             // Remove the keyword from the buffer
             buffer = String(buffer.dropLast(keyword.count))
+
+            let isShell = snippet.mode.caseInsensitiveCompare("shell") == .orderedSame
+            if isShell {
+                nextShellReplacementID &+= 1
+                let replacementID = nextShellReplacementID
+                pendingShellReplacement = PendingShellReplacement(
+                    id: replacementID,
+                    keyword: keyword,
+                    bufferPrefix: buffer
+                )
+                lock.unlock()
+
+                // Keep the final trigger character in the target app. This
+                // makes cancellation lossless if input changes while zsh runs.
+                DispatchQueue.main.async {
+                    performReplacement(
+                        keyword: keyword,
+                        snippet: snippet,
+                        replacementID: replacementID
+                    )
+                }
+                return Unmanaged.passRetained(event)
+            }
+
             lock.unlock()
 
             // Perform replacement on main thread
             DispatchQueue.main.async {
-                performReplacement(keyword: keyword, snippet: snippet)
+                performReplacement(keyword: keyword, snippet: snippet, replacementID: nil)
             }
 
             // Suppress the last keystroke (it's part of the keyword)
@@ -221,6 +276,23 @@ final class TextExpander {
 
         lock.unlock()
         return Unmanaged.passRetained(event)
+    }
+
+    /// Cancel a pending shell replacement and restore its trigger context in
+    /// the rolling buffer.
+    private static func cancelPendingShellReplacement(_ id: UInt64? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
+        cancelPendingShellReplacementLocked(id)
+    }
+
+    /// Caller must hold `lock`.
+    private static func cancelPendingShellReplacementLocked(_ id: UInt64? = nil) {
+        guard let pending = pendingShellReplacement else { return }
+        if let id, pending.id != id { return }
+        pendingShellReplacement = nil
+        let restored = pending.bufferPrefix + pending.keyword
+        buffer = String(restored.suffix(maxBufferLength))
     }
 
     /// Check if the buffer ends with any snippet keyword.
@@ -237,21 +309,30 @@ final class TextExpander {
     }
 
     /// Delete the keyword characters and type the expansion.
-    private static func performReplacement(keyword: String, snippet: SnippetDefinition) {
+    private static func performReplacement(
+        keyword: String,
+        snippet: SnippetDefinition,
+        replacementID: UInt64?
+    ) {
         if snippet.mode.caseInsensitiveCompare("shell") == .orderedSame {
+            guard let replacementID, hasPendingShellReplacement(replacementID) else { return }
             let clipboardText = NSPasteboard.general.string(forType: .string)
             DispatchQueue.global(qos: .userInitiated).async {
                 guard let cStr = rc_snippet_execute(snippet.command, clipboardText) else {
-                    // The final trigger character was suppressed; restore the full keyword.
                     DispatchQueue.main.async {
-                        replaceKeywordAndPaste(keywordLength: keyword.count, text: keyword)
+                        cancelPendingShellReplacement(replacementID)
                     }
                     return
                 }
                 let output = String(cString: cStr)
                 rc_free_string(cStr)
                 DispatchQueue.main.async {
-                    replaceKeywordAndPaste(keywordLength: keyword.count, text: output)
+                    guard claimPendingShellReplacement(replacementID) else { return }
+                    replaceKeywordAndPaste(
+                        keywordLength: keyword.count,
+                        text: output,
+                        suppressedTrigger: false
+                    )
                 }
             }
             return
@@ -263,14 +344,35 @@ final class TextExpander {
             resolved = String(cString: cStr)
             rc_free_string(cStr)
         }
-        replaceKeywordAndPaste(keywordLength: keyword.count, text: resolved)
+        replaceKeywordAndPaste(keywordLength: keyword.count, text: resolved, suppressedTrigger: true)
     }
 
-    private static func replaceKeywordAndPaste(keywordLength: Int, text: String) {
+    private static func hasPendingShellReplacement(_ id: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pendingShellReplacement?.id == id
+    }
+
+    private static func claimPendingShellReplacement(_ id: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard pendingShellReplacement?.id == id else { return false }
+        pendingShellReplacement = nil
+        return true
+    }
+
+    private static func replaceKeywordAndPaste(
+        keywordLength: Int,
+        text: String,
+        suppressedTrigger: Bool
+    ) {
         let source = CGEventSource(stateID: .combinedSessionState)
 
-        // Step 1: Send backspace to delete the keyword (minus the last char which was suppressed)
-        for _ in 0..<(keywordLength - 1) {
+        // Step 1: Delete the keyword. Text snippets have their final trigger
+        // character suppressed; shell snippets leave it in the target app so
+        // cancellation can preserve all user input.
+        let backspaceCount = keywordLength - (suppressedTrigger ? 1 : 0)
+        for _ in 0..<max(0, backspaceCount) {
             let backDown = CGEvent(keyboardEventSource: source, virtualKey: 51, keyDown: true)
             backDown?.post(tap: .cghidEventTap)
             let backUp = CGEvent(keyboardEventSource: source, virtualKey: 51, keyDown: false)

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -15,6 +15,8 @@ final class SearchPanel: NSPanel {
     /// Floating action panel window.
     private var actionWindow: NSWindow?
     private var actionSelectedIndex = 0
+    private var isOrderingOut = false
+    private var workspaceObserver: NSObjectProtocol?
 
     init() {
         let mainView = MainView(viewModel: viewModel)
@@ -74,12 +76,30 @@ final class SearchPanel: NSPanel {
         }
 
         viewModel.loadAISettings()
+
+        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !self.isVisible else { return }
+                // The panel is hidden while an async shell result is pending.
+                // A subsequent app switch means the original paste target is stale.
+                self.viewModel.invalidatePendingShellExecution()
+            }
+        }
     }
 
     /// Whether the user has ever positioned the panel manually.
     private var hasUserPosition = false
 
     func showPanel() {
+        // A new launcher session must not accept a result from an older shell
+        // snippet execution.
+        viewModel.invalidatePendingShellExecution()
+        isOrderingOut = false
+
         // Remember the currently focused app before showing
         previousApp = NSWorkspace.shared.frontmostApplication
 
@@ -108,8 +128,15 @@ final class SearchPanel: NSPanel {
     }
 
     func hidePanel() {
+        isOrderingOut = true
         hideActionPanel()
         orderOut(nil)
+        // Keep the flag through any synchronous resignKey callback caused by
+        // orderOut, then allow a later user-driven focus loss to invalidate
+        // pending shell work.
+        DispatchQueue.main.async { [weak self] in
+            self?.isOrderingOut = false
+        }
     }
 
     /// Hide panel, re-activate the previous app, and simulate Cmd+V to paste.
@@ -256,6 +283,11 @@ final class SearchPanel: NSPanel {
     // Auto-hide when losing focus
     override func resignKey() {
         super.resignKey()
+        if !isOrderingOut {
+            // Losing focus changes the app/caret that a completed result would
+            // target, so discard work started by the previous panel session.
+            viewModel.invalidatePendingShellExecution()
+        }
         hidePanel()
     }
 

--- a/AintoApp/Sources/Views/SnippetView.swift
+++ b/AintoApp/Sources/Views/SnippetView.swift
@@ -318,6 +318,7 @@ struct SnippetEditForm: View {
                             Text("Shell").tag("shell")
                         }
                         .pickerStyle(.segmented)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     if viewModel.editingSnippet?.mode.caseInsensitiveCompare("shell") == .orderedSame {

--- a/AintoApp/Sources/Views/SnippetView.swift
+++ b/AintoApp/Sources/Views/SnippetView.swift
@@ -179,9 +179,9 @@ struct SnippetItemRow: View {
                     .font(.system(size: 13))
                     .foregroundColor(isSelected ? .white : .primary)
                     .lineLimit(1)
-                Text(snippet.keyword)
+                Text(snippet.keyword.isEmpty ? "No keyword" : snippet.keyword)
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(isSelected ? .white.opacity(0.7) : .gray)
+                    .foregroundColor(isSelected ? .white.opacity(0.78) : .secondary)
                     .lineLimit(1)
             }
 
@@ -215,7 +215,9 @@ struct SnippetPreview: View {
             VStack(spacing: 0) {
                 // Expansion preview
                 ScrollView {
-                    Text(expandedText)
+                    Text(snippet.mode.caseInsensitiveCompare("shell") == .orderedSame
+                         ? (snippet.command.isEmpty ? "No command configured" : snippet.command)
+                         : expandedText)
                         .font(.system(size: 13, design: .monospaced))
                         .foregroundColor(.primary)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -236,6 +238,7 @@ struct SnippetPreview: View {
 
                     MetadataRow(label: "Name", value: snippet.name)
                     MetadataRow(label: "Keyword", value: snippet.keyword)
+                    MetadataRow(label: "Mode", value: snippet.mode.capitalized)
                     MetadataRow(label: "Characters", value: "\(snippet.expansion.count)")
                 }
                 .padding(12)
@@ -309,6 +312,32 @@ struct SnippetEditForm: View {
                         viewModel.focusFilterField()
                     }
 
+                    FormRow(label: "Mode") {
+                        Picker("Snippet mode", selection: binding(\.mode)) {
+                            Text("Text").tag("text")
+                            Text("Shell").tag("shell")
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    if viewModel.editingSnippet?.mode.caseInsensitiveCompare("shell") == .orderedSame {
+                        FormRow(label: "Command") {
+                            VStack(alignment: .leading, spacing: 8) {
+                                TextEditor(text: binding(\.command))
+                                    .font(.system(size: 13, design: .monospaced))
+                                    .scrollContentBackground(.hidden)
+                                    .padding(8)
+                                    .frame(minHeight: 100)
+                                    .background(Color.primary.opacity(0.06))
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                                Text("Runs /bin/zsh when triggered. Output is pasted after the command succeeds.")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    } else {
+
                     // Snippet (expansion text)
                     FormRow(label: "Snippet") {
                         VStack(alignment: .leading, spacing: 8) {
@@ -324,6 +353,7 @@ struct SnippetEditForm: View {
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
                         }
+                    }
                     }
 
                     // Keyword

--- a/ainto-core/src/ai_commands.rs
+++ b/ainto-core/src/ai_commands.rs
@@ -39,32 +39,44 @@ fn default_commands() -> Vec<AiCommand> {
         AiCommand {
             name: "Fix Spelling & Grammar".into(),
             icon: Some("text.badge.checkmark".into()),
-            prompt: format!("{SYS}\n\nFix the spelling and grammar of the following text:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nFix the spelling and grammar of the following text:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Improve Writing".into(),
             icon: Some("text.badge.star".into()),
-            prompt: format!("{SYS}\n\nImprove the writing quality. Make it clearer and more professional:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nImprove the writing quality. Make it clearer and more professional:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Make Shorter".into(),
             icon: Some("arrow.down.right.and.arrow.up.left".into()),
-            prompt: format!("{SYS}\n\nMake the following text more concise while keeping the meaning:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nMake the following text more concise while keeping the meaning:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Make Longer".into(),
             icon: Some("arrow.up.left.and.arrow.down.right".into()),
-            prompt: format!("{SYS}\n\nExpand and elaborate on the following text:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nExpand and elaborate on the following text:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Change Tone to Professional".into(),
             icon: Some("briefcase".into()),
-            prompt: format!("{SYS}\n\nRewrite the following text in a professional tone:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nRewrite the following text in a professional tone:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Change Tone to Casual".into(),
             icon: Some("face.smiling".into()),
-            prompt: format!("{SYS}\n\nRewrite the following text in a casual, friendly tone:\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nRewrite the following text in a casual, friendly tone:\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Translate to English".into(),
@@ -74,7 +86,9 @@ fn default_commands() -> Vec<AiCommand> {
         AiCommand {
             name: "Translate to Traditional Chinese".into(),
             icon: Some("globe.asia.australia".into()),
-            prompt: format!("{SYS}\n\nTranslate the following text to Traditional Chinese (繁體中文):\n\n{{selection}}"),
+            prompt: format!(
+                "{SYS}\n\nTranslate the following text to Traditional Chinese (繁體中文):\n\n{{selection}}"
+            ),
         },
         AiCommand {
             name: "Explain This".into(),

--- a/ainto-core/src/claude.rs
+++ b/ainto-core/src/claude.rs
@@ -19,7 +19,11 @@ pub struct ClaudeSession {
 
 impl ClaudeSession {
     /// Start a new Claude session, or resume an existing one.
-    pub fn start(query: &str, binary: &str, resume_session_id: Option<&str>) -> Result<Self, Error> {
+    pub fn start(
+        query: &str,
+        binary: &str,
+        resume_session_id: Option<&str>,
+    ) -> Result<Self, Error> {
         // Validate binary name: reject empty strings and dangerous characters
         if binary.is_empty() {
             return Err(Error::ClaudeSpawn("claude_binary must not be empty".into()));
@@ -46,9 +50,8 @@ impl ClaudeSession {
 
         let path_env = std::env::var("PATH").unwrap_or_default();
         let home = std::env::var("HOME").unwrap_or_default();
-        let extended_path = format!(
-            "{home}/.local/bin:/usr/local/bin:/opt/homebrew/bin:{path_env}"
-        );
+        let extended_path =
+            format!("{home}/.local/bin:/usr/local/bin:/opt/homebrew/bin:{path_env}");
 
         let mut cmd = Command::new(&resolved_binary);
         cmd.arg("-p")
@@ -76,9 +79,10 @@ impl ClaudeSession {
             .spawn()
             .map_err(|e| Error::ClaudeSpawn(e.to_string()))?;
 
-        let stdout = child.stdout.take().ok_or(Error::ClaudeSpawn(
-            "failed to capture stdout".to_string(),
-        ))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(Error::ClaudeSpawn("failed to capture stdout".to_string()))?;
 
         Ok(Self {
             child,
@@ -130,7 +134,11 @@ impl ClaudeSession {
         // Read all stderr
         let stderr_text = if let Some(stderr) = self.child.stderr.take() {
             let reader = BufReader::new(stderr);
-            reader.lines().filter_map(|l| l.ok()).collect::<Vec<_>>().join("\n")
+            reader
+                .lines()
+                .filter_map(|l| l.ok())
+                .collect::<Vec<_>>()
+                .join("\n")
         } else {
             String::new()
         };

--- a/ainto-core/src/clipboard_store.rs
+++ b/ainto-core/src/clipboard_store.rs
@@ -148,7 +148,11 @@ impl ClipboardStore {
         self.get_recent_paged(limit, 0)
     }
 
-    pub fn get_recent_paged(&self, limit: usize, offset: usize) -> Result<Vec<ClipboardEntry>, Error> {
+    pub fn get_recent_paged(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<ClipboardEntry>, Error> {
         let mut stmt = self.db.prepare(
             "SELECT id, content_type, text_content, image_path, hash, source_app, last_copied_at, copy_count
              FROM clipboard_items
@@ -199,7 +203,12 @@ impl ClipboardStore {
         self.search_paged(query, 50, 0)
     }
 
-    pub fn search_paged(&self, query: &str, limit: usize, offset: usize) -> Result<Vec<ClipboardEntry>, Error> {
+    pub fn search_paged(
+        &self,
+        query: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<ClipboardEntry>, Error> {
         let pattern = format!("%{query}%");
         let mut stmt = self.db.prepare(
             "SELECT id, content_type, text_content, image_path, hash, source_app, last_copied_at, copy_count
@@ -214,7 +223,9 @@ impl ClipboardStore {
                 let content_type: String = row.get(1)?;
                 let text: Option<String> = row.get(2)?;
                 let content = match content_type.as_str() {
-                    "file" => ClipboardContent::File { path: text.unwrap_or_default() },
+                    "file" => ClipboardContent::File {
+                        path: text.unwrap_or_default(),
+                    },
                     _ => ClipboardContent::Text(text.unwrap_or_default()),
                 };
                 Ok(ClipboardEntry {
@@ -254,9 +265,9 @@ impl ClipboardStore {
 
     /// Clear all entries.
     pub fn clear(&mut self) -> Result<(), Error> {
-        let mut stmt = self.db.prepare(
-            "SELECT image_path FROM clipboard_items WHERE image_path IS NOT NULL",
-        )?;
+        let mut stmt = self
+            .db
+            .prepare("SELECT image_path FROM clipboard_items WHERE image_path IS NOT NULL")?;
         let paths: Vec<String> = stmt
             .query_map([], |row| row.get(0))?
             .filter_map(|r| r.ok())
@@ -310,7 +321,9 @@ impl ClipboardStore {
         );
         let mut stmt = self.db.prepare(&select_sql)?;
         let items: Vec<(i64, Option<String>)> = stmt
-            .query_map(params![to_delete as i64], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .query_map(params![to_delete as i64], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })?
             .filter_map(|r| r.ok())
             .collect();
 
@@ -353,9 +366,6 @@ pub fn rgba_to_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, Erro
     let img: ImageBuffer<Rgba<u8>, _> =
         ImageBuffer::from_raw(width, height, rgba.to_vec()).ok_or(Error::ImageEncode)?;
     let mut buf = Vec::new();
-    img.write_to(
-        &mut std::io::Cursor::new(&mut buf),
-        image::ImageFormat::Png,
-    )?;
+    img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)?;
     Ok(buf)
 }

--- a/ainto-core/src/discovery.rs
+++ b/ainto-core/src/discovery.rs
@@ -208,10 +208,10 @@ fn query_app(path: &Path, store_icons: bool) -> Option<AppEntry> {
     let is_truthy = |key: &NSString| -> bool {
         info.objectForKey(key)
             .map(|v| {
-                v.downcast_ref::<NSNumber>()
-                    .is_some_and(|n| n.boolValue())
-                    || v.downcast_ref::<NSString>()
-                        .is_some_and(|s| s.to_string() == "1" || s.to_string().eq_ignore_ascii_case("YES"))
+                v.downcast_ref::<NSNumber>().is_some_and(|n| n.boolValue())
+                    || v.downcast_ref::<NSString>().is_some_and(|s| {
+                        s.to_string() == "1" || s.to_string().eq_ignore_ascii_case("YES")
+                    })
             })
             .unwrap_or(false)
     };
@@ -241,10 +241,7 @@ fn query_app(path: &Path, store_icons: bool) -> Option<AppEntry> {
         .or_else(|| get_localized_string(ns_string!("CFBundleName")))
         .or_else(|| get_string(ns_string!("CFBundleDisplayName")))
         .or_else(|| get_string(ns_string!("CFBundleName")))
-        .or_else(|| {
-            path.file_stem()
-                .map(|s| s.to_string_lossy().into_owned())
-        })?;
+        .or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()))?;
 
     let icon_png = if store_icons {
         icon_of_path(path.to_str().unwrap_or(""))
@@ -267,7 +264,7 @@ fn query_app(path: &Path, store_icons: bool) -> Option<AppEntry> {
 
 /// Get all installed applications.
 pub fn get_installed_apps(store_icons: bool) -> Vec<AppEntry> {
-        let paths = registered_app_urls().unwrap_or_else(|| {
+    let paths = registered_app_urls().unwrap_or_else(|| {
         // Fallback: scan known directories
         let mut paths = Vec::new();
         for dir in USER_APP_DIRS.iter() {
@@ -289,7 +286,13 @@ pub fn get_installed_apps(store_icons: bool) -> Vec<AppEntry> {
         .collect();
 
     // Dedup by bundle_id: prefer /Applications/ path over build directories
-    apps.sort_by_key(|a| if a.path.starts_with("/Applications/") { 0 } else { 1 });
+    apps.sort_by_key(|a| {
+        if a.path.starts_with("/Applications/") {
+            0
+        } else {
+            1
+        }
+    });
     let mut seen_ids = std::collections::HashSet::new();
     apps.retain(|app| {
         match &app.bundle_id {

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -27,7 +27,10 @@ fn from_c_str(s: *const c_char) -> Option<String> {
     if s.is_null() {
         return None;
     }
-    unsafe { CStr::from_ptr(s) }.to_str().ok().map(|s| s.to_string())
+    unsafe { CStr::from_ptr(s) }
+        .to_str()
+        .ok()
+        .map(|s| s.to_string())
 }
 
 // ============================================================
@@ -173,7 +176,9 @@ pub extern "C" fn rc_get_top_apps(limit: u64) -> *const c_char {
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_increment_ranking(key: *const c_char) -> i32 {
     let Some(k) = from_c_str(key) else { return -1 };
-    let Ok(cfg_dir) = config::config_dir() else { return -1 };
+    let Ok(cfg_dir) = config::config_dir() else {
+        return -1;
+    };
     let path = cfg_dir.join("ranking.toml");
     let score = crate::ranking::increment_and_save(&path, &k);
 
@@ -192,7 +197,9 @@ pub extern "C" fn rc_increment_ranking(key: *const c_char) -> i32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_get_ranking(key: *const c_char) -> i32 {
     let Some(k) = from_c_str(key) else { return 0 };
-    let Ok(cfg_dir) = config::config_dir() else { return 0 };
+    let Ok(cfg_dir) = config::config_dir() else {
+        return 0;
+    };
     let path = cfg_dir.join("ranking.toml");
     crate::ranking::get_score(&path, &k)
 }
@@ -202,7 +209,9 @@ pub extern "C" fn rc_update_ranking(app_path: *const c_char) {
     let Some(key) = from_c_str(app_path) else {
         return;
     };
-    let Ok(cfg_dir) = config::config_dir() else { return };
+    let Ok(cfg_dir) = config::config_dir() else {
+        return;
+    };
     let path = cfg_dir.join("ranking.toml");
     let score = crate::ranking::increment_and_save(&path, &key);
 
@@ -261,10 +270,7 @@ pub extern "C" fn rc_clipboard_set_limits(max_text_items: u64, max_image_items: 
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rc_clipboard_insert_text(
-    text: *const c_char,
-    source_app: *const c_char,
-) -> i64 {
+pub extern "C" fn rc_clipboard_insert_text(text: *const c_char, source_app: *const c_char) -> i64 {
     let Some(text_str) = from_c_str(text) else {
         return -1;
     };
@@ -318,10 +324,7 @@ pub extern "C" fn rc_clipboard_insert_image(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rc_clipboard_insert_file(
-    path: *const c_char,
-    source_app: *const c_char,
-) -> i64 {
+pub extern "C" fn rc_clipboard_insert_file(path: *const c_char, source_app: *const c_char) -> i64 {
     let Some(path_str) = from_c_str(path) else {
         return -1;
     };
@@ -406,7 +409,11 @@ pub extern "C" fn rc_clipboard_search(query: *const c_char) -> *const c_char {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rc_clipboard_search_paged(query: *const c_char, limit: u64, offset: u64) -> *const c_char {
+pub extern "C" fn rc_clipboard_search_paged(
+    query: *const c_char,
+    limit: u64,
+    offset: u64,
+) -> *const c_char {
     let Some(q) = from_c_str(query) else {
         return to_c_string("[]");
     };

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -495,6 +495,21 @@ pub extern "C" fn rc_snippet_expand(
     to_c_string(&result)
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn rc_snippet_execute(
+    command: *const c_char,
+    clipboard_text: *const c_char,
+) -> *const c_char {
+    let Some(command) = from_c_str(command) else {
+        return ptr::null();
+    };
+    let clip = from_c_str(clipboard_text);
+    match snippets::execute_shell(&command, clip.as_deref()) {
+        Ok(output) => to_c_string(&output),
+        Err(_) => ptr::null(),
+    }
+}
+
 // ============================================================
 // AI Commands
 // ============================================================

--- a/ainto-core/src/lib.rs
+++ b/ainto-core/src/lib.rs
@@ -38,4 +38,7 @@ pub enum Error {
 
     #[error("Claude spawn error: {0}")]
     ClaudeSpawn(String),
+
+    #[error("Shell execution error: {0}")]
+    ShellExecution(String),
 }

--- a/ainto-core/src/lib.rs
+++ b/ainto-core/src/lib.rs
@@ -3,8 +3,8 @@
 //! This crate compiles to a static library (.a) linked into the Swift frontend via C ABI FFI.
 
 pub mod ai_commands;
-pub mod clipboard_store;
 pub mod claude;
+pub mod clipboard_store;
 pub mod config;
 pub mod discovery;
 pub mod ffi;

--- a/ainto-core/src/search.rs
+++ b/ainto-core/src/search.rs
@@ -79,7 +79,10 @@ impl AppIndex {
     }
 
     /// Apply frecency rankings loaded from disk.
-    pub fn apply_rankings(&mut self, rankings: &std::collections::HashMap<String, crate::ranking::RankingEntry>) {
+    pub fn apply_rankings(
+        &mut self,
+        rankings: &std::collections::HashMap<String, crate::ranking::RankingEntry>,
+    ) {
         for app in &mut self.apps {
             if let Some(entry) = rankings.get(&app.path) {
                 app.ranking = entry.frecency_score();
@@ -177,7 +180,10 @@ fn word_boundary_match(query: &str, display_name: &str) -> bool {
     }
 
     // Check if query is a subsequence of the initials
-    let initials_lower: Vec<char> = initials.iter().map(|c| c.to_lowercase().next().unwrap_or(*c)).collect();
+    let initials_lower: Vec<char> = initials
+        .iter()
+        .map(|c| c.to_lowercase().next().unwrap_or(*c))
+        .collect();
     let mut qi = 0;
     for &ic in &initials_lower {
         if qi < query_chars.len() && ic == query_chars[qi] {
@@ -201,7 +207,10 @@ fn extract_word_boundaries(name: &str) -> Vec<char> {
         } else if c.is_uppercase() && i > 0 && chars[i - 1].is_lowercase() {
             // camelCase boundary: "OrbStack" → S
             boundaries.push(c);
-        } else if i > 0 && (chars[i - 1] == ' ' || chars[i - 1] == '-' || chars[i - 1] == '_') && c.is_alphanumeric() {
+        } else if i > 0
+            && (chars[i - 1] == ' ' || chars[i - 1] == '-' || chars[i - 1] == '_')
+            && c.is_alphanumeric()
+        {
             // Word boundary after separator
             boundaries.push(c);
         }
@@ -212,7 +221,10 @@ fn extract_word_boundaries(name: &str) -> Vec<char> {
 /// CamelCase aware subsequence: query chars match at case-change boundaries.
 fn camel_case_match(query: &str, display_name: &str) -> bool {
     let boundaries = extract_word_boundaries(display_name);
-    let boundary_str: String = boundaries.iter().map(|c| c.to_lowercase().next().unwrap_or(*c)).collect();
+    let boundary_str: String = boundaries
+        .iter()
+        .map(|c| c.to_lowercase().next().unwrap_or(*c))
+        .collect();
     let query_lc = query.to_lowercase();
     is_subsequence(&query_lc, &boundary_str)
 }

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -92,6 +92,25 @@ impl Snippet {
 const SHELL_TIMEOUT: Duration = Duration::from_secs(3);
 const MAX_SHELL_OUTPUT: usize = 1024 * 1024;
 
+/// Stop the shell and any descendants that inherited its stdout pipe.
+fn cleanup_shell_process_group(child: &mut std::process::Child) {
+    #[cfg(target_os = "macos")]
+    {
+        // `process_group(0)` makes the child the leader of a new process
+        // group. A negative PID targets the whole group, including any
+        // descendants that still hold stdout open.
+        let process_group = child.id() as libc::pid_t;
+        if process_group > 0 {
+            unsafe {
+                libc::kill(-process_group, libc::SIGKILL);
+            }
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 /// Execute an explicitly configured shell snippet and return stdout.
 /// Commands are resolved with the same placeholders as text snippets.
 pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<String, Error> {
@@ -128,13 +147,25 @@ pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<Stri
 
     let deadline = Instant::now() + SHELL_TIMEOUT;
     loop {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|e| Error::ShellExecution(e.to_string()))?
-        {
-            let (_, bytes) = receiver
-                .recv_timeout(Duration::from_millis(100))
-                .map_err(|_| Error::ShellExecution("failed to read stdout".into()))?;
+        let status = match child.try_wait() {
+            Ok(status) => status,
+            Err(error) => {
+                cleanup_shell_process_group(&mut child);
+                return Err(Error::ShellExecution(error.to_string()));
+            }
+        };
+        if let Some(status) = status {
+            let (read_result, bytes) = match receiver.recv_timeout(Duration::from_millis(100)) {
+                Ok(result) => result,
+                Err(_) => {
+                    cleanup_shell_process_group(&mut child);
+                    return Err(Error::ShellExecution("failed to read stdout".into()));
+                }
+            };
+            if read_result.is_err() {
+                cleanup_shell_process_group(&mut child);
+                return Err(Error::ShellExecution("failed to read stdout".into()));
+            }
             if bytes.len() > MAX_SHELL_OUTPUT {
                 return Err(Error::ShellExecution("stdout exceeds 1 MiB".into()));
             }
@@ -149,20 +180,7 @@ pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<Stri
         }
 
         if Instant::now() >= deadline {
-            #[cfg(target_os = "macos")]
-            {
-                // `process_group(0)` makes the child the leader of a new
-                // process group. A negative PID targets the whole group,
-                // including descendants spawned by the shell command.
-                let process_group = child.id() as libc::pid_t;
-                if process_group > 0 {
-                    unsafe {
-                        libc::kill(-process_group, libc::SIGKILL);
-                    }
-                }
-            }
-            let _ = child.kill();
-            let _ = child.wait();
+            cleanup_shell_process_group(&mut child);
             return Err(Error::ShellExecution(
                 "command timed out after 3 seconds".into(),
             ));
@@ -473,6 +491,26 @@ mod tests {
 
         // Without process-group cleanup, the descendant would still run and
         // create the marker after the parent zsh has timed out.
+        std::thread::sleep(Duration::from_secs(2));
+        assert!(!marker.exists());
+        let _ = std::fs::remove_file(marker);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_shell_stdout_failure_kills_descendant_processes() {
+        let marker = std::env::temp_dir().join(format!(
+            "ainto-shell-stdout-failure-{}.marker",
+            uuid::Uuid::new_v4()
+        ));
+        let quoted_marker = format!("'{}'", marker.to_string_lossy().replace('\'', "'\"'\"'"));
+        let command = format!("(sleep 1; : > {quoted_marker}) & exit 0");
+
+        let error = execute_shell(&command, None).unwrap_err();
+        assert!(error.to_string().contains("failed to read stdout"));
+
+        // The descendant inherited stdout after the parent shell exited. It
+        // must still be killed when stdout collection fails or times out.
         std::thread::sleep(Duration::from_secs(2));
         assert!(!marker.exists());
         let _ = std::fs::remove_file(marker);

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -6,6 +6,9 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
+use std::os::unix::process::CommandExt;
+
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::Error;
@@ -93,12 +96,21 @@ const MAX_SHELL_OUTPUT: usize = 1024 * 1024;
 /// Commands are resolved with the same placeholders as text snippets.
 pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<String, Error> {
     let command = resolve_shell_placeholders(command);
-    let mut child = Command::new("/bin/zsh")
+    if command.trim().is_empty() {
+        return Err(Error::ShellExecution("shell command is empty".into()));
+    }
+
+    let mut shell = Command::new("/bin/zsh");
+    shell
         .args(["-c", &command])
         .env("AINTO_SNIPPET_CLIPBOARD", clipboard_text.unwrap_or(""))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(target_os = "macos")]
+    shell.process_group(0);
+
+    let mut child = shell
         .spawn()
         .map_err(|e| Error::ShellExecution(e.to_string()))?;
 
@@ -137,6 +149,18 @@ pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<Stri
         }
 
         if Instant::now() >= deadline {
+            #[cfg(target_os = "macos")]
+            {
+                // `process_group(0)` makes the child the leader of a new
+                // process group. A negative PID targets the whole group,
+                // including descendants spawned by the shell command.
+                let process_group = child.id() as libc::pid_t;
+                if process_group > 0 {
+                    unsafe {
+                        libc::kill(-process_group, libc::SIGKILL);
+                    }
+                }
+            }
             let _ = child.kill();
             let _ = child.wait();
             return Err(Error::ShellExecution(
@@ -426,6 +450,32 @@ mod tests {
     #[test]
     fn test_shell_command_failure_is_not_output() {
         assert!(execute_shell("exit 7", None).is_err());
+    }
+
+    #[test]
+    fn test_empty_shell_command_is_rejected() {
+        let error = execute_shell("  \n\t", None).unwrap_err();
+        assert!(error.to_string().contains("shell command is empty"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_shell_timeout_kills_descendant_processes() {
+        let marker = std::env::temp_dir().join(format!(
+            "ainto-shell-timeout-{}.marker",
+            uuid::Uuid::new_v4()
+        ));
+        let quoted_marker = format!("'{}'", marker.to_string_lossy().replace('\'', "'\"'\"'"));
+        let command = format!("(sleep 4; : > {quoted_marker}) & wait");
+
+        let error = execute_shell(&command, None).unwrap_err();
+        assert!(error.to_string().contains("timed out after 3 seconds"));
+
+        // Without process-group cleanup, the descendant would still run and
+        // create the marker after the parent zsh has timed out.
+        std::thread::sleep(Duration::from_secs(2));
+        assert!(!marker.exists());
+        let _ = std::fs::remove_file(marker);
     }
 
     #[test]

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -1,17 +1,60 @@
 //! Snippet management with TOML persistence and placeholder resolution.
 
+use std::io::Read;
 use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::Error;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Snippet {
     pub id: String,
     pub name: String,
+    #[serde(default = "default_mode")]
+    pub mode: String,
     pub keyword: String,
+    #[serde(default)]
     pub expansion: String,
+    #[serde(default)]
+    pub command: String,
+}
+
+fn default_mode() -> String {
+    "text".into()
+}
+
+impl Serialize for Snippet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct SnippetWire<'a> {
+            id: &'a str,
+            name: &'a str,
+            mode: &'a str,
+            keyword: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            expansion: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            command: Option<&'a str>,
+        }
+
+        let shell = self.is_shell();
+        SnippetWire {
+            id: &self.id,
+            name: &self.name,
+            mode: &self.mode,
+            keyword: &self.keyword,
+            expansion: (!shell && !self.expansion.is_empty()).then_some(&self.expansion),
+            command: (shell && !self.command.is_empty()).then_some(&self.command),
+        }
+        .serialize(serializer)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -28,12 +71,74 @@ impl Snippet {
             name,
             keyword,
             expansion,
+            mode: default_mode(),
+            command: String::new(),
         }
     }
 
     /// Get the expanded text with placeholders resolved.
     pub fn expand(&self, clipboard_text: Option<&str>) -> String {
         resolve_placeholders(&self.expansion, clipboard_text)
+    }
+
+    pub fn is_shell(&self) -> bool {
+        self.mode.eq_ignore_ascii_case("shell")
+    }
+}
+
+const SHELL_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_SHELL_OUTPUT: usize = 1024 * 1024;
+
+/// Execute an explicitly configured shell snippet and return stdout.
+/// Commands are resolved with the same placeholders as text snippets.
+pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<String, Error> {
+    let command = resolve_placeholders(command, clipboard_text);
+    let mut child = Command::new("/bin/zsh")
+        .args(["-c", &command])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| Error::ShellExecution(e.to_string()))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::ShellExecution("stdout unavailable".into()))?;
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut limited = stdout.take((MAX_SHELL_OUTPUT + 1) as u64);
+        let result = limited.read_to_end(&mut bytes);
+        let _ = sender.send((result, bytes));
+    });
+
+    let deadline = Instant::now() + SHELL_TIMEOUT;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| Error::ShellExecution(e.to_string()))?
+        {
+            let (_, bytes) = receiver
+                .recv_timeout(Duration::from_millis(100))
+                .map_err(|_| Error::ShellExecution("failed to read stdout".into()))?;
+            if bytes.len() > MAX_SHELL_OUTPUT {
+                return Err(Error::ShellExecution("stdout exceeds 1 MiB".into()));
+            }
+            if !status.success() {
+                return Err(Error::ShellExecution(format!("command exited with {status}")));
+            }
+            let output = String::from_utf8(bytes)
+                .map_err(|_| Error::ShellExecution("stdout is not UTF-8".into()))?;
+            return Ok(output.trim_end_matches(['\r', '\n']).to_string());
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(Error::ShellExecution("command timed out after 3 seconds".into()));
+        }
+        std::thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -207,5 +312,87 @@ mod tests {
         let snippet = Snippet::new("Test".into(), "!test".into(), "Today is {date}".into());
         let expanded = snippet.expand(None);
         assert!(expanded.starts_with("Today is "));
+    }
+
+    #[test]
+    fn test_shell_command_output_is_trimmed() {
+        let output = execute_shell("printf 'hello\\n'", None).unwrap();
+        assert_eq!(output, "hello");
+    }
+
+    #[test]
+    fn test_shell_command_resolves_placeholders() {
+        let output = execute_shell("printf '%s' '{clipboard}'", Some("copied")).unwrap();
+        assert_eq!(output, "copied");
+    }
+
+    #[test]
+    fn test_shell_command_failure_is_not_output() {
+        assert!(execute_shell("exit 7", None).is_err());
+    }
+
+    #[test]
+    fn test_legacy_snippet_defaults_to_text_mode() {
+        let snippet: Snippet = toml::from_str(
+            r#"
+            id = "legacy"
+            name = "Legacy"
+            keyword = ";legacy"
+            expansion = "hello"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(snippet.mode, "text");
+        assert!(snippet.command.is_empty());
+    }
+
+    #[test]
+    fn test_mode_specific_toml_fields() {
+        let text = Snippet::new("Text".into(), ";text".into(), "hello".into());
+        let text_toml = toml::to_string(&text).unwrap();
+        assert!(text_toml.contains("mode = \"text\""));
+        assert!(text_toml.contains("expansion = \"hello\""));
+        assert!(!text_toml.contains("command ="));
+
+        let shell = Snippet {
+            id: "shell".into(),
+            name: "Shell".into(),
+            mode: "shell".into(),
+            keyword: ";shell".into(),
+            expansion: "ignored".into(),
+            command: "printf ok".into(),
+        };
+        let shell_toml = toml::to_string(&shell).unwrap();
+        assert!(shell_toml.contains("mode = \"shell\""));
+        assert!(shell_toml.contains("command = \"printf ok\""));
+        assert!(!shell_toml.contains("expansion ="));
+        assert!(shell_toml.find("name =").unwrap() < shell_toml.find("mode =").unwrap());
+    }
+
+    #[test]
+    fn test_mode_specific_records_without_empty_fields_load() {
+        let file: SnippetFile = toml::from_str(
+            r#"
+            [[snippets]]
+            id = "text"
+            name = "ok"
+            mode = "text"
+            keyword = ";ok"
+            expansion = "test"
+
+            [[snippets]]
+            id = "shell"
+            name = "branch"
+            mode = "shell"
+            keyword = ";branch"
+            command = "printf main"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(file.snippets.len(), 2);
+        assert_eq!(file.snippets[0].expansion, "test");
+        assert!(file.snippets[0].command.is_empty());
+        assert!(file.snippets[1].expansion.is_empty());
+        assert_eq!(file.snippets[1].command, "printf main");
     }
 }

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -92,9 +92,10 @@ const MAX_SHELL_OUTPUT: usize = 1024 * 1024;
 /// Execute an explicitly configured shell snippet and return stdout.
 /// Commands are resolved with the same placeholders as text snippets.
 pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<String, Error> {
-    let command = resolve_placeholders(command, clipboard_text);
+    let command = resolve_shell_placeholders(command);
     let mut child = Command::new("/bin/zsh")
         .args(["-c", &command])
+        .env("AINTO_SNIPPET_CLIPBOARD", clipboard_text.unwrap_or(""))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -126,7 +127,9 @@ pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<Stri
                 return Err(Error::ShellExecution("stdout exceeds 1 MiB".into()));
             }
             if !status.success() {
-                return Err(Error::ShellExecution(format!("command exited with {status}")));
+                return Err(Error::ShellExecution(format!(
+                    "command exited with {status}"
+                )));
             }
             let output = String::from_utf8(bytes)
                 .map_err(|_| Error::ShellExecution("stdout is not UTF-8".into()))?;
@@ -136,7 +139,9 @@ pub fn execute_shell(command: &str, clipboard_text: Option<&str>) -> Result<Stri
         if Instant::now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
-            return Err(Error::ShellExecution("command timed out after 3 seconds".into()));
+            return Err(Error::ShellExecution(
+                "command timed out after 3 seconds".into(),
+            ));
         }
         std::thread::sleep(Duration::from_millis(10));
     }
@@ -174,6 +179,10 @@ pub fn save_snippets(path: &Path, snippets: &[Snippet]) -> Result<(), Error> {
 /// - `{clipboard}` → current clipboard text
 /// - `{uuid}` → random UUID
 pub fn resolve_placeholders(text: &str, clipboard_text: Option<&str>) -> String {
+    resolve_static_placeholders(text).replace("{clipboard}", clipboard_text.unwrap_or(""))
+}
+
+fn resolve_static_placeholders(text: &str) -> String {
     use std::time::SystemTime;
 
     let now = SystemTime::now()
@@ -189,8 +198,82 @@ pub fn resolve_placeholders(text: &str, clipboard_text: Option<&str>) -> String 
 
     text.replace("{date}", &date_str)
         .replace("{time}", &time_str)
-        .replace("{clipboard}", clipboard_text.unwrap_or(""))
         .replace("{uuid}", &uuid::Uuid::new_v4().to_string())
+}
+
+const SHELL_CLIPBOARD_VAR: &str = "\"$AINTO_SNIPPET_CLIPBOARD\"";
+
+/// Resolve placeholders for shell commands without interpolating clipboard text
+/// into zsh source. Clipboard data is passed through an environment variable;
+/// single-quoted placeholders are rewritten with a safely quoted literal because
+/// variables do not expand inside single quotes.
+fn resolve_shell_placeholders(text: &str) -> String {
+    let resolved = resolve_static_placeholders(text);
+    let chars: Vec<char> = resolved.chars().collect();
+    let placeholder: Vec<char> = "{clipboard}".chars().collect();
+    let single_quote = 39 as char;
+    // A parameter expansion inside double quotes is not reparsed as shell code.
+    let quoted_clipboard = "\"$AINTO_SNIPPET_CLIPBOARD\"";
+
+    let mut output = String::with_capacity(text.len());
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    let mut index = 0;
+
+    while index < chars.len() {
+        let ch = chars[index];
+
+        if escaped {
+            output.push(ch);
+            escaped = false;
+            index += 1;
+            continue;
+        }
+
+        if ch == '\\' && quote != Some(single_quote) {
+            output.push(ch);
+            escaped = true;
+            index += 1;
+            continue;
+        }
+
+        if index + placeholder.len() <= chars.len()
+            && chars[index..index + placeholder.len()] == placeholder[..]
+        {
+            if quote == Some(single_quote) {
+                // Close the surrounding single quote, insert a shell-quoted
+                // value, then reopen it so surrounding text remains quoted.
+                output.push(single_quote);
+                output.push_str(quoted_clipboard);
+                output.push(single_quote);
+            } else if quote == Some('"') {
+                // The surrounding double quotes already protect expansion.
+                output.push_str("$AINTO_SNIPPET_CLIPBOARD");
+            } else {
+                output.push_str(SHELL_CLIPBOARD_VAR);
+            }
+            index += placeholder.len();
+            continue;
+        }
+
+        if ch == single_quote {
+            if quote == Some(single_quote) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(single_quote);
+            }
+        } else if ch == '"' {
+            if quote == Some('"') {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some('"');
+            }
+        }
+        output.push(ch);
+        index += 1;
+    }
+
+    output
 }
 
 /// Convert a Unix timestamp to local date/time without adding a date-time crate.
@@ -324,6 +407,20 @@ mod tests {
     fn test_shell_command_resolves_placeholders() {
         let output = execute_shell("printf '%s' '{clipboard}'", Some("copied")).unwrap();
         assert_eq!(output, "copied");
+    }
+
+    #[test]
+    fn test_shell_clipboard_is_not_reparsed_as_code() {
+        let clipboard = "O'Reilly; $(printf injected) && echo compromised";
+        let output = execute_shell("printf '%s' '{clipboard}'", Some(clipboard)).unwrap();
+        assert_eq!(output, clipboard);
+    }
+
+    #[test]
+    fn test_shell_clipboard_is_safe_inside_double_quotes() {
+        let clipboard = "$(printf injected) 'quoted'";
+        let output = execute_shell("printf '%s' \"{clipboard}\"", Some(clipboard)).unwrap();
+        assert_eq!(output, clipboard);
     }
 
     #[test]

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -196,16 +196,15 @@ mod tests {
 
     #[test]
     fn test_missing_clipboard_resolves_to_empty() {
-        assert_eq!(resolve_placeholders("before{clipboard}after", None), "beforeafter");
+        assert_eq!(
+            resolve_placeholders("before{clipboard}after", None),
+            "beforeafter"
+        );
     }
 
     #[test]
     fn test_snippet_expand() {
-        let snippet = Snippet::new(
-            "Test".into(),
-            "!test".into(),
-            "Today is {date}".into(),
-        );
+        let snippet = Snippet::new("Test".into(), "!test".into(), "Today is {date}".into());
         let expanded = snippet.expand(None);
         assert!(expanded.starts_with("Today is "));
     }


### PR DESCRIPTION
Add an opt-in shell execution mode for snippets, with safe placeholder handling, timeout/process cleanup.

After using it for a few days, I haven't found any issues. There are quite a few changes, and I'm not sure if they align with the roadmap. On my local branch, I've also added features like themes and more keyboard shortcut bindings.

## What changed

- Add backward-compatible `text` and `shell` snippet modes.
- Execute shell snippets through `/bin/zsh` with:
  - Safe clipboard placeholder handling
  - 3-second timeout
  - 1 MiB stdout limit
  - UTF-8 validation and trimmed output
  - Process-group cleanup for descendants
- Integrate shell snippets with:
  - Global text expansion
  - Launcher search results
  - Snippet management and paste workflows
- Cancel stale replacements when the target app or caret changes.
- Prevent stale asynchronous results from pasting after navigation, launcher reopen, or newer executions.
- Add Mode picker and shell command editor to the snippet UI.

## Backward compatibility

Existing snippets without a mode continue to load as regular text snippets.

## Validation

- `cargo test` — 25 tests passed
- `cargo fmt -- --check`
- `swift build --disable-sandbox`
