### PR TITLE
Add file search and macOS system actions

### DIFF
--- a/AintoApp/Package.swift
+++ b/AintoApp/Package.swift
@@ -35,7 +35,14 @@ let package = Package(
                 .linkedFramework("AppKit"),
                 .linkedFramework("Security"),
                 .linkedFramework("SystemConfiguration"),
+                .linkedFramework("QuickLookUI"),
+                .linkedFramework("UniformTypeIdentifiers"),
             ]
+        ),
+        .testTarget(
+            name: "AintoAppTests",
+            dependencies: ["AintoApp"],
+            path: "Tests"
         ),
     ]
 )

--- a/AintoApp/Resources/Ainto-Debug.entitlements
+++ b/AintoApp/Resources/Ainto-Debug.entitlements
@@ -6,5 +6,7 @@
     <false/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
 </dict>
 </plist>

--- a/AintoApp/Resources/Ainto.entitlements
+++ b/AintoApp/Resources/Ainto.entitlements
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <false/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
 </dict>
 </plist>

--- a/AintoApp/Resources/Info.plist
+++ b/AintoApp/Resources/Info.plist
@@ -34,6 +34,8 @@
     <string></string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Ainto uses macOS automation to perform the system actions you explicitly run.</string>
 
     <!-- Sparkle Auto-Update Configuration -->
     <key>SUFeedURL</key>

--- a/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Foundation
+
+extension SearchViewModel {
+    func fileSearchCommandResult(score: Int) -> SearchResult {
+        SearchResult(
+            title: "File Search",
+            subtitle: "Search files and folders with Spotlight",
+            icon: nil,
+            systemIcon: "doc.text.magnifyingglass",
+            score: score
+        ) { [weak self] in
+            self?.goToFileSearch()
+        }
+    }
+
+    func systemActionResult(_ action: SystemAction, score: Int) -> SearchResult {
+        SearchResult(
+            title: action.title,
+            subtitle: action.requiresConfirmation ? "System Action • Confirmation required" : "System Action",
+            icon: nil,
+            systemIcon: action.icon,
+            score: score
+        ) { [weak self] in
+            self?.requestSystemAction(action)
+        }
+    }
+
+    func requestSystemAction(_ action: SystemAction) {
+        systemActionError = nil
+        pendingSystemAction = action
+        if action.requiresConfirmation {
+            page = .systemConfirmation
+        } else {
+            // Keep the panel visible so failures from immediate actions are shown.
+            page = .systemConfirmation
+            executeSystemAction(action)
+        }
+    }
+
+    func confirmSystemAction() {
+        guard let action = pendingSystemAction else {
+            goBack()
+            return
+        }
+        executeSystemAction(action)
+    }
+
+    func cancelSystemAction() {
+        guard !isExecutingSystemAction else { return }
+        pendingSystemAction = nil
+        systemActionError = nil
+        page = .main
+        focusFilterField()
+    }
+
+    private func executeSystemAction(_ action: SystemAction) {
+        guard !isExecutingSystemAction else { return }
+        isExecutingSystemAction = true
+        systemActionError = nil
+        Task { [weak self] in
+            let errorMessage = await Task.detached { () -> String? in
+                do {
+                    try SystemActionService.execute(action)
+                    return nil
+                } catch {
+                    return error.localizedDescription
+                }
+            }.value
+            guard let self else { return }
+            isExecutingSystemAction = false
+            if let errorMessage {
+                pendingSystemAction = action
+                systemActionError = errorMessage
+                page = .systemConfirmation
+            } else {
+                pendingSystemAction = nil
+                page = .main
+                onSystemActionCompleted?()
+            }
+        }
+    }
+}

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -453,14 +453,9 @@ final class SearchViewModel: ObservableObject {
         // stale "Restart?" prompt leaves a destructive action one Return away,
         // with nothing to show how long it has been sitting there. An action
         // already executing is left alone, matching `goBack()`.
-        if page == .systemConfirmation, !isExecutingSystemAction {
-            pendingSystemAction = nil
-            systemActionError = nil
-        } else if page == .fileSearch {
-            fileSearch.clear()
-        } else {
-            return
-        }
+        guard page == .systemConfirmation, !isExecutingSystemAction else { return }
+        pendingSystemAction = nil
+        systemActionError = nil
         page = .main
         searchMode = .apps
         query = ""

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -449,8 +449,18 @@ final class SearchViewModel: ObservableObject {
     }
 
     func prepareForPanelHide() {
-        guard page == .fileSearch else { return }
-        fileSearch.clear()
+        // A pending confirmation must not outlive the panel. Reopening on a
+        // stale "Restart?" prompt leaves a destructive action one Return away,
+        // with nothing to show how long it has been sitting there. An action
+        // already executing is left alone, matching `goBack()`.
+        if page == .systemConfirmation, !isExecutingSystemAction {
+            pendingSystemAction = nil
+            systemActionError = nil
+        } else if page == .fileSearch {
+            fileSearch.clear()
+        } else {
+            return
+        }
         page = .main
         searchMode = .apps
         query = ""

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length cyclomatic_complexity
 import AppKit
 import Foundation
 import AintoCore
@@ -118,6 +119,8 @@ enum LauncherPage: Equatable {
     case clipboard
     case snippets
     case aiCommands
+    case fileSearch
+    case systemConfirmation
     case claude
 }
 
@@ -290,6 +293,12 @@ final class SearchViewModel: ObservableObject {
     @Published var page: LauncherPage = .main
     @Published var searchMode: SearchMode = .apps
 
+    let fileSearch = FileSearchService()
+    @Published var pendingSystemAction: SystemAction?
+    @Published var systemActionError: String?
+    @Published var isExecutingSystemAction = false
+    var onSystemActionCompleted: (() -> Void)?
+
     // Claude state
     @Published var claudeMessages: [ClaudeMessage] = []
     @Published var claudeIsStreaming = false
@@ -432,7 +441,25 @@ final class SearchViewModel: ObservableObject {
         focusFilterField()
     }
 
+    func goToFileSearch() {
+        page = .fileSearch
+        fileSearch.clear()
+        fileSearch.reloadConfiguration()
+        focusFilterField()
+    }
+
+    func prepareForPanelHide() {
+        guard page == .fileSearch else { return }
+        fileSearch.clear()
+        page = .main
+        searchMode = .apps
+        query = ""
+        selectedIndex = 0
+        results = buildDefaultResults()
+    }
+
     func goBack() {
+        if page == .systemConfirmation && isExecutingSystemAction { return }
         if page == .claude {
             claudeCancel()
             claudeMessages.removeAll()
@@ -442,6 +469,11 @@ final class SearchViewModel: ObservableObject {
             cancelEditingAICommand()
             return
         }
+        if page == .fileSearch {
+            fileSearch.clear()
+        }
+        pendingSystemAction = nil
+        systemActionError = nil
         clipboardFilter = "" // didSet handles cancel + debouncedClipboardFilter
         page = .main
         searchMode = .apps
@@ -608,6 +640,14 @@ final class SearchViewModel: ObservableObject {
             commandResults.append(r)
         }
 
+        if q == "f" || fuzzyMatch(q, "file search") {
+            commandResults.append(fileSearchCommandResult(score: q == "f" ? 300 : fuzzyScore(q, "File Search")))
+        }
+
+        for action in SystemAction.allCases where fuzzyMatch(q, action.title) {
+            commandResults.append(systemActionResult(action, score: fuzzyScore(q, action.title)))
+        }
+
         var allResults = appResults + commandResults + snippetResults
         allResults.sort { $0.score > $1.score }
         results = Array(allResults.prefix(20))
@@ -629,11 +669,13 @@ final class SearchViewModel: ObservableObject {
             let count = filteredAICommands.count
             guard count > 0 else { return }
             aiCommandSelectedIndex = max(0, min(aiCommandSelectedIndex + offset, count - 1))
+        case .fileSearch:
+            fileSearch.moveSelection(by: offset)
         case .main:
             guard !results.isEmpty else { return }
             selectedIndex = max(0, min(selectedIndex + offset, results.count - 1))
-        case .claude:
-            break // no list navigation in Claude view
+        case .systemConfirmation, .claude:
+            break // no list navigation on these pages
         }
     }
 
@@ -645,6 +687,10 @@ final class SearchViewModel: ObservableObject {
             expandSelectedSnippet()
         case .aiCommands:
             executeSelectedAICommand()
+        case .fileSearch:
+            fileSearch.openSelected()
+        case .systemConfirmation:
+            confirmSystemAction()
         case .main:
             guard selectedIndex < results.count else { return }
             results[selectedIndex].action()
@@ -900,6 +946,7 @@ final class SearchViewModel: ObservableObject {
               let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
         aiEnabled = config["ai_enabled"] as? Bool ?? true
         claudeBinary = (config["claude_binary"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "claude"
+        fileSearch.reloadConfiguration()
         exitAISurfacesIfDisabled()
     }
 
@@ -1007,8 +1054,23 @@ final class SearchViewModel: ObservableObject {
         case .main:
             guard selectedIndex < results.count else { return [] }
             return results[selectedIndex].actions
+        case .fileSearch:
+            guard fileSearch.results.indices.contains(fileSearch.selectedIndex) else { return [] }
+            return fileSearch.actions(for: fileSearch.results[fileSearch.selectedIndex])
         default:
             return []
+        }
+    }
+
+    var currentActionTitle: String {
+        switch page {
+        case .main:
+            return results.indices.contains(selectedIndex) ? results[selectedIndex].title : ""
+        case .fileSearch:
+            return fileSearch.results.indices.contains(fileSearch.selectedIndex)
+                ? fileSearch.results[fileSearch.selectedIndex].title : ""
+        default:
+            return ""
         }
     }
 
@@ -1090,6 +1152,8 @@ final class SearchViewModel: ObservableObject {
             icon: nil,
             systemIcon: "doc.on.clipboard"
         ) { [weak self] in self?.goToClipboard() })
+
+        results.append(fileSearchCommandResult(score: 0))
 
         results.append(SearchResult(
             title: "Snippets",

--- a/AintoApp/Sources/Services/FileSearchService.swift
+++ b/AintoApp/Sources/Services/FileSearchService.swift
@@ -1,0 +1,287 @@
+import AppKit
+import Foundation
+import AintoCore
+import QuickLookUI
+import UniformTypeIdentifiers
+
+struct FileSearchItem: Identifiable, Hashable {
+    let url: URL
+    let isDirectory: Bool
+
+    var id: String { url.path }
+    var title: String { url.lastPathComponent }
+    var subtitle: String { url.deletingLastPathComponent().path }
+    var icon: NSImage { NSWorkspace.shared.icon(forFile: url.path) }
+}
+
+/// Owns one cancellable Spotlight query at a time and publishes only results
+/// from the latest generation.
+@MainActor
+final class FileSearchService: NSObject, ObservableObject {
+    @Published var queryText: String = "" {
+        didSet { scheduleSearch() }
+    }
+    @Published private(set) var results: [FileSearchItem] = []
+    @Published private(set) var isSearching = false
+    @Published private(set) var errorMessage: String?
+    @Published var selectedIndex = 0
+    var onOpen: (() -> Void)?
+
+    private var metadataQuery: NSMetadataQuery?
+    private var debounceWork: DispatchWorkItem?
+    private var searchPaths: [String] = []
+    private var allLocations = false
+    private var includeHidden = false
+    private var configurationLoaded = false
+
+    func reloadConfiguration() {
+        guard let cString = rc_config_load() else {
+            configurationLoaded = false
+            searchPaths = []
+            allLocations = false
+            errorMessage = "File Search settings could not be loaded. Check config.toml in Settings."
+            return
+        }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            configurationLoaded = false
+            searchPaths = []
+            allLocations = false
+            errorMessage = "File Search settings could not be loaded. Check config.toml in Settings."
+            return
+        }
+        searchPaths = (config["file_search_paths"] as? [String])?
+            .map { URL(fileURLWithPath: $0).standardizedFileURL.resolvingSymlinksInPath().path }
+            .filter { !$0.isEmpty } ?? []
+        allLocations = config["file_search_all_locations"] as? Bool ?? false
+        includeHidden = config["file_search_include_hidden"] as? Bool ?? false
+        configurationLoaded = true
+        errorMessage = allLocations || !searchPaths.isEmpty
+            ? nil
+            : "Choose at least one File Search folder in Settings."
+    }
+
+    func clear() {
+        queryText = ""
+        cancelQuery()
+        results = []
+        selectedIndex = 0
+        errorMessage = nil
+    }
+
+    func moveSelection(by offset: Int) {
+        guard !results.isEmpty else { return }
+        selectedIndex = max(0, min(selectedIndex + offset, results.count - 1))
+    }
+
+    func openSelected() {
+        guard results.indices.contains(selectedIndex),
+              openIfStillEligible(results[selectedIndex].url)
+        else { return }
+        onOpen?()
+    }
+
+    func actions(for item: FileSearchItem) -> [ActionItem] {
+        let url = item.url
+        return [
+            ActionItem(title: "Open", icon: "arrow.up.forward.app", shortcut: "↵") { [weak self] in
+                _ = self?.openIfStillEligible(url)
+            },
+            ActionItem(title: "Show in Finder", icon: "folder", shortcut: nil) {
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            },
+            ActionItem(title: "Quick Look", icon: "eye", shortcut: nil) { [weak self] in
+                guard self?.eligibleItem(at: url) != nil else { return }
+                QuickLookPreviewController.shared.preview(url)
+            },
+            ActionItem(title: "Copy Path", icon: "doc.on.doc", shortcut: nil) {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(url.path, forType: .string)
+            },
+            ActionItem(title: "Open With…", icon: "square.and.arrow.up", shortcut: nil) { [weak self] in
+                guard self?.eligibleItem(at: url) != nil else { return }
+                Self.chooseApplicationAndOpen(url)
+            }
+        ]
+    }
+
+    private func scheduleSearch() {
+        // Stop the previous Spotlight query immediately. Otherwise it can finish
+        // during the debounce interval and briefly publish stale results.
+        cancelQuery()
+        let trimmed = queryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            results = []
+            selectedIndex = 0
+            return
+        }
+        guard configurationLoaded, allLocations || !searchPaths.isEmpty else {
+            results = []
+            selectedIndex = 0
+            if errorMessage == nil {
+                errorMessage = "Choose at least one File Search folder in Settings."
+            }
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in
+            self?.startSearch(trimmed)
+        }
+        debounceWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)
+    }
+
+    private func startSearch(_ text: String) {
+        guard text == queryText.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+        cancelQuery()
+        let query = NSMetadataQuery()
+        query.predicate = NSPredicate(format: "%K CONTAINS[cd] %@", NSMetadataItemFSNameKey, text)
+        query.sortDescriptors = [
+            NSSortDescriptor(
+                key: NSMetadataItemFSNameKey,
+                ascending: true,
+                selector: #selector(NSString.localizedStandardCompare(_:))
+            )
+        ]
+        if allLocations {
+            query.searchScopes = [NSMetadataQueryLocalComputerScope]
+        } else {
+            query.searchScopes = searchPaths.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(queryDidFinish(_:)),
+            name: .NSMetadataQueryDidFinishGathering,
+            object: query
+        )
+        metadataQuery = query
+        query.operationQueue = .main
+        isSearching = true
+        errorMessage = nil
+        guard query.start() else {
+            isSearching = false
+            errorMessage = "Spotlight search could not start."
+            stop(query)
+            return
+        }
+    }
+
+    @objc private func queryDidFinish(_ notification: Notification) {
+        guard let query = notification.object as? NSMetadataQuery,
+              query === metadataQuery else { return }
+        query.disableUpdates()
+        let items = query.results.compactMap { result -> FileSearchItem? in
+            guard let metadata = result as? NSMetadataItem,
+                  let path = metadata.value(forAttribute: NSMetadataItemPathKey) as? String
+            else { return nil }
+            return eligibleItem(at: URL(fileURLWithPath: path))
+        }
+        query.enableUpdates()
+        results = Array(items
+            .sorted {
+                if $0.isDirectory != $1.isDirectory { return $0.isDirectory }
+                return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+            }
+            .prefix(100))
+        selectedIndex = 0
+        isSearching = false
+        stop(query)
+    }
+
+    func eligibleItem(at url: URL) -> FileSearchItem? {
+        let standardizedURL = url.standardizedFileURL
+        let resolvedURL = standardizedURL.resolvingSymlinksInPath()
+        guard isWithinConfiguredScope(resolvedURL) else { return nil }
+        if resolvedURL.pathComponents.contains(where: { $0.lowercased().hasSuffix(".app") }) {
+            return nil
+        }
+        let keys: Set<URLResourceKey> = [.isDirectoryKey, .isRegularFileKey, .isHiddenKey, .isExecutableKey]
+        guard let values = try? resolvedURL.resourceValues(forKeys: keys) else { return nil }
+        let isDirectory = values.isDirectory == true
+        guard isDirectory || values.isRegularFile == true else { return nil }
+        let hasHiddenComponent = resolvedURL.pathComponents.contains { component in
+            component.hasPrefix(".") && component != "." && component != ".."
+        }
+        if !includeHidden && (values.isHidden == true || hasHiddenComponent) { return nil }
+        let isExecutable = values.isExecutable == true
+            || FileManager.default.isExecutableFile(atPath: resolvedURL.path)
+        if !isDirectory && isExecutable { return nil }
+        return FileSearchItem(url: standardizedURL, isDirectory: isDirectory)
+    }
+
+    private func isWithinConfiguredScope(_ url: URL) -> Bool {
+        guard !allLocations else { return true }
+        let candidate = url.path
+        return searchPaths.contains { scopePath in
+            candidate == scopePath || candidate.hasPrefix(scopePath.hasSuffix("/") ? scopePath : scopePath + "/")
+        }
+    }
+
+    @discardableResult
+    private func openIfStillEligible(_ url: URL) -> Bool {
+        guard let item = eligibleItem(at: url) else {
+            results.removeAll { $0.url == url }
+            selectedIndex = min(selectedIndex, max(0, results.count - 1))
+            errorMessage = "The item is no longer eligible for File Search."
+            return false
+        }
+        guard NSWorkspace.shared.open(item.url) else {
+            errorMessage = "The item could not be opened."
+            return false
+        }
+        return true
+    }
+
+    private func cancelQuery() {
+        debounceWork?.cancel()
+        debounceWork = nil
+        if let query = metadataQuery { stop(query) }
+        metadataQuery = nil
+        isSearching = false
+    }
+
+    private func stop(_ query: NSMetadataQuery) {
+        NotificationCenter.default.removeObserver(self, name: .NSMetadataQueryDidFinishGathering, object: query)
+        query.stop()
+        if metadataQuery === query { metadataQuery = nil }
+    }
+
+    private static func chooseApplicationAndOpen(_ url: URL) {
+        let panel = NSOpenPanel()
+        panel.title = "Choose an application"
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.application]
+        guard panel.runModal() == .OK, let applicationURL = panel.url else { return }
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: applicationURL,
+            configuration: configuration
+        )
+    }
+}
+
+@MainActor
+private final class QuickLookPreviewController: NSObject, @preconcurrency QLPreviewPanelDataSource {
+    static let shared = QuickLookPreviewController()
+    private var url: URL?
+
+    func preview(_ url: URL) {
+        self.url = url
+        guard let panel = QLPreviewPanel.shared() else { return }
+        panel.dataSource = self
+        panel.reloadData()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int { url == nil ? 0 : 1 }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> any QLPreviewItem {
+        (url ?? URL(fileURLWithPath: "/")) as NSURL
+    }
+}

--- a/AintoApp/Sources/Services/SystemActionService.swift
+++ b/AintoApp/Sources/Services/SystemActionService.swift
@@ -1,0 +1,117 @@
+import AppKit
+import Foundation
+
+enum SystemAction: String, CaseIterable, Identifiable {
+    case sleep
+    case lockScreen = "lock-screen"
+    case logOut = "log-out"
+    case restart
+    case shutDown = "shut-down"
+    case emptyTrash = "empty-trash"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .sleep: "Sleep"
+        case .lockScreen: "Lock Screen"
+        case .logOut: "Log Out"
+        case .restart: "Restart"
+        case .shutDown: "Shut Down"
+        case .emptyTrash: "Empty Trash"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .sleep: "moon.zzz"
+        case .lockScreen: "lock.fill"
+        case .logOut: "rectangle.portrait.and.arrow.right"
+        case .restart: "restart"
+        case .shutDown: "power"
+        case .emptyTrash: "trash"
+        }
+    }
+
+    var requiresConfirmation: Bool {
+        switch self {
+        case .logOut, .restart, .shutDown: true
+        default: false
+        }
+    }
+}
+
+enum SystemActionError: LocalizedError {
+    case unavailable(String)
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let message), .failed(let message): message
+        }
+    }
+}
+
+enum SystemActionService {
+    /// Executes only fixed operations selected from `SystemAction`.
+    static func execute(_ action: SystemAction) throws {
+        switch action {
+        case .sleep:
+            try run("/usr/bin/pmset", arguments: ["sleepnow"])
+        case .lockScreen:
+            try lockScreen()
+        case .emptyTrash:
+            try runAppleScript("tell application \"Finder\" to empty trash")
+        case .logOut:
+            try runAppleScript("tell application \"System Events\" to log out")
+        case .restart:
+            try runAppleScript("tell application \"System Events\" to restart")
+        case .shutDown:
+            try runAppleScript("tell application \"System Events\" to shut down")
+        }
+    }
+
+    private static func lockScreen() throws {
+        guard AXIsProcessTrusted() else {
+            throw SystemActionError.unavailable("Enable Accessibility access for Ainto to lock the screen.")
+        }
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x0C, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x0C, keyDown: false)
+        else {
+            throw SystemActionError.unavailable("The macOS lock screen shortcut is unavailable.")
+        }
+        let flags: CGEventFlags = [.maskCommand, .maskControl]
+        keyDown.flags = flags
+        keyUp.flags = flags
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    private static func runAppleScript(_ fixedScript: String) throws {
+        try run("/usr/bin/osascript", arguments: ["-e", fixedScript])
+    }
+
+    private static func run(_ executable: String, arguments: [String]) throws {
+        guard FileManager.default.isExecutableFile(atPath: executable) else {
+            throw SystemActionError.unavailable("The macOS system helper is unavailable.")
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw SystemActionError.failed(error.localizedDescription)
+        }
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw SystemActionError.failed(message.flatMap { $0.isEmpty ? nil : $0 } ?? "The system action failed.")
+        }
+    }
+}

--- a/AintoApp/Sources/Views/FileSearchSettingsView.swift
+++ b/AintoApp/Sources/Views/FileSearchSettingsView.swift
@@ -10,64 +10,51 @@ struct FileSearchSettingsView: View {
         VStack(alignment: .leading, spacing: 24) {
             SectionHeader(title: "File Search", icon: "doc.text.magnifyingglass")
 
-            SettingsCard {
-                VStack(alignment: .leading, spacing: 14) {
-                    SettingsRow(label: "Search entire Mac") {
-                        Toggle("", isOn: $allLocations).labelsHidden().toggleStyle(.switch)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Search scope")
+                    .font(.system(size: 14, weight: .medium))
+                SettingsCard {
+                    Picker("Search scope", selection: $allLocations) {
+                        Text("Selected Folders").tag(false)
+                        Text("Entire Mac").tag(true)
                     }
-                    Text(
-                        "Full Disk Access grants permission, while this toggle expands "
-                            + "the Spotlight scope beyond the folders below."
-                    )
-                        .font(.system(size: 11))
-                        .foregroundStyle(.tertiary)
-                    Divider().opacity(0.3)
-                    SettingsRow(label: "Include hidden files") {
-                        Toggle("", isOn: $includeHidden).labelsHidden().toggleStyle(.switch)
-                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
                 }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Search folders")
-                        .font(.system(size: 14, weight: .medium))
-                    Spacer()
-                    Button("Add Folder…") { addFolder() }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(Color.accentColor)
-                }
+            if allLocations {
                 SettingsCard {
-                    VStack(spacing: 10) {
-                        ForEach(paths, id: \.self) { path in
-                            HStack(spacing: 10) {
-                                Image(systemName: "folder")
-                                    .foregroundStyle(.secondary)
-                                Text(path)
-                                    .font(.system(size: 12, design: .monospaced))
-                                    .lineLimit(1)
-                                Spacer()
-                                Button {
-                                    paths.removeAll { $0 == path }
-                                } label: {
-                                    Image(systemName: "minus.circle")
-                                        .foregroundStyle(.secondary)
-                                        .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-                                .help("Remove folder")
-                            }
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: "internaldrive")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.accentColor)
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text("Search the entire Mac using Spotlight")
+                                .font(.system(size: 13, weight: .medium))
+                            Text("Only indexed files are searched; Ainto never crawls the disk.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                            Text(savedFoldersMessage)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.tertiary)
                         }
+                        Spacer()
                     }
                 }
-                if paths.isEmpty && !allLocations {
-                    Text("Add at least one folder or enable Search entire Mac.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.orange)
-                } else if allLocations {
-                    Text("These folders will be used when Search entire Mac is turned off.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.tertiary)
+            } else {
+                selectedFoldersSection
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Search options")
+                    .font(.system(size: 14, weight: .medium))
+                SettingsCard {
+                    SettingsRow(label: "Include hidden files") {
+                        Toggle("", isOn: $includeHidden)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                    }
                 }
             }
 
@@ -78,18 +65,73 @@ struct FileSearchSettingsView: View {
                             .font(.system(size: 13))
                         Text(
                             "Allows Spotlight to return more protected indexed locations. "
-                                + "It does not scan unindexed files."
+                                + "It does not change the search scope or scan unindexed files."
                         )
                             .font(.system(size: 11))
                             .foregroundStyle(.tertiary)
                     }
                     Spacer()
-                    Button("Open Settings") { openFullDiskAccessSettings() }
+                    Button("Open System Settings") { openFullDiskAccessSettings() }
                         .buttonStyle(.plain)
                         .foregroundStyle(Color.accentColor)
                 }
             }
         }
+    }
+
+    private var selectedFoldersSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Search folders")
+                    .font(.system(size: 14, weight: .medium))
+                Spacer()
+                Button("Add Folder…") { addFolder() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+            }
+            SettingsCard {
+                VStack(spacing: 10) {
+                    if paths.isEmpty {
+                        Text("No folders selected")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    ForEach(paths, id: \.self) { path in
+                        HStack(spacing: 10) {
+                            Image(systemName: "folder")
+                                .foregroundStyle(.secondary)
+                            Text(path)
+                                .font(.system(size: 12, design: .monospaced))
+                                .lineLimit(1)
+                            Spacer()
+                            Button {
+                                paths.removeAll { $0 == path }
+                            } label: {
+                                Image(systemName: "minus.circle")
+                                    .foregroundStyle(.secondary)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .help("Remove folder")
+                        }
+                    }
+                }
+            }
+            if paths.isEmpty {
+                Text("Add at least one folder to enable File Search in this mode.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var savedFoldersMessage: String {
+        guard !paths.isEmpty else {
+            return "Switch to Selected Folders to choose a narrower search scope."
+        }
+        let noun = paths.count == 1 ? "folder is" : "folders are"
+        return "Your \(paths.count) configured \(noun) preserved for Selected Folders mode."
     }
 
     private func addFolder() {
@@ -109,9 +151,8 @@ struct FileSearchSettingsView: View {
     }
 
     private func openFullDiskAccessSettings() {
-        // Permission alone does not change NSMetadataQuery's scope. Enable the
-        // whole-Mac scope so returning from System Settings behaves as expected.
-        allLocations = true
+        // Permission and search scope are independent. Opening System Settings
+        // must not silently switch from Selected Folders to Entire Mac.
         let primary = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
         if !NSWorkspace.shared.open(primary),
            let fallback = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension") {

--- a/AintoApp/Sources/Views/FileSearchSettingsView.swift
+++ b/AintoApp/Sources/Views/FileSearchSettingsView.swift
@@ -1,0 +1,121 @@
+import AppKit
+import SwiftUI
+
+struct FileSearchSettingsView: View {
+    @Binding var paths: [String]
+    @Binding var allLocations: Bool
+    @Binding var includeHidden: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SectionHeader(title: "File Search", icon: "doc.text.magnifyingglass")
+
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    SettingsRow(label: "Search entire Mac") {
+                        Toggle("", isOn: $allLocations).labelsHidden().toggleStyle(.switch)
+                    }
+                    Text(
+                        "Full Disk Access grants permission, while this toggle expands "
+                            + "the Spotlight scope beyond the folders below."
+                    )
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                    Divider().opacity(0.3)
+                    SettingsRow(label: "Include hidden files") {
+                        Toggle("", isOn: $includeHidden).labelsHidden().toggleStyle(.switch)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Search folders")
+                        .font(.system(size: 14, weight: .medium))
+                    Spacer()
+                    Button("Add Folder…") { addFolder() }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.accentColor)
+                }
+                SettingsCard {
+                    VStack(spacing: 10) {
+                        ForEach(paths, id: \.self) { path in
+                            HStack(spacing: 10) {
+                                Image(systemName: "folder")
+                                    .foregroundStyle(.secondary)
+                                Text(path)
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .lineLimit(1)
+                                Spacer()
+                                Button {
+                                    paths.removeAll { $0 == path }
+                                } label: {
+                                    Image(systemName: "minus.circle")
+                                        .foregroundStyle(.secondary)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove folder")
+                            }
+                        }
+                    }
+                }
+                if paths.isEmpty && !allLocations {
+                    Text("Add at least one folder or enable Search entire Mac.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                } else if allLocations {
+                    Text("These folders will be used when Search entire Mac is turned off.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            SettingsCard {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Full Disk Access")
+                            .font(.system(size: 13))
+                        Text(
+                            "Allows Spotlight to return more protected indexed locations. "
+                                + "It does not scan unindexed files."
+                        )
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Button("Open Settings") { openFullDiskAccessSettings() }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+        }
+    }
+
+    private func addFolder() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a File Search folder"
+        // Start at the filesystem root so system folders such as /Library are
+        // visible without requiring the user to know Finder's Go to Folder shortcut.
+        panel.directoryURL = URL(fileURLWithPath: "/", isDirectory: true)
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            let path = url.standardizedFileURL.resolvingSymlinksInPath().path
+            if !paths.contains(path) { paths.append(path) }
+        }
+    }
+
+    private func openFullDiskAccessSettings() {
+        // Permission alone does not change NSMetadataQuery's scope. Enable the
+        // whole-Mac scope so returning from System Settings behaves as expected.
+        allLocations = true
+        let primary = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
+        if !NSWorkspace.shared.open(primary),
+           let fallback = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension") {
+            NSWorkspace.shared.open(fallback)
+        }
+    }
+}

--- a/AintoApp/Sources/Views/FileSearchView.swift
+++ b/AintoApp/Sources/Views/FileSearchView.swift
@@ -1,0 +1,196 @@
+import AppKit
+import SwiftUI
+
+struct FileSearchView: View {
+    @ObservedObject var viewModel: SearchViewModel
+    @ObservedObject var service: FileSearchService
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Button(action: { viewModel.goBack() }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+
+                Image(systemName: "doc.text.magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 16))
+
+                TextField("Search files and folders…", text: $service.queryText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 16))
+                    .focused($focused)
+                    .onAppear {
+                        service.reloadConfiguration()
+                        focused = true
+                    }
+                if service.isSearching {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+
+            Divider().opacity(0.5)
+
+            if let error = service.errorMessage {
+                ContentUnavailableView("Search unavailable", systemImage: "exclamationmark.triangle", description: Text(error))
+                    .frame(height: 330)
+            } else if service.queryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ContentUnavailableView(
+                    "File Search",
+                    systemImage: "doc.text.magnifyingglass",
+                    description: Text("Type a filename to search the folders configured in Settings.")
+                )
+                .frame(height: 330)
+            } else if service.results.isEmpty && !service.isSearching {
+                ContentUnavailableView("No files found", systemImage: "doc.text.magnifyingglass")
+                    .frame(height: 330)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 2) {
+                            ForEach(Array(service.results.enumerated()), id: \.element.id) { index, item in
+                                FileSearchResultRow(item: item, selected: index == service.selectedIndex)
+                                    .id(item.id)
+                                    .onTapGesture(count: 2) {
+                                        service.selectedIndex = index
+                                        service.openSelected()
+                                    }
+                                    .onTapGesture {
+                                        service.selectedIndex = index
+                                    }
+                                    .contextMenu {
+                                        ForEach(service.actions(for: item)) { action in
+                                            Button(action: action.action) {
+                                                Label(action.title, systemImage: action.icon)
+                                            }
+                                        }
+                                    }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .frame(height: 330)
+                    .onChange(of: service.selectedIndex) { _, index in
+                        guard service.results.indices.contains(index) else { return }
+                        proxy.scrollTo(service.results[index].id)
+                    }
+                }
+            }
+
+            Divider().opacity(0.3)
+            HStack {
+                Text("\(service.results.count) results")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                HStack(spacing: 12) {
+                    KeyHint(keys: ["⌘", "K"], label: "actions")
+                    KeyHint(keys: ["↑", "↓"], label: "navigate")
+                    KeyHint(keys: ["↵"], label: "open")
+                    KeyHint(keys: ["esc"], label: "back")
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 680)
+    }
+}
+
+private struct FileSearchResultRow: View {
+    let item: FileSearchItem
+    let selected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: item.icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.system(size: 14, weight: selected ? .semibold : .regular))
+                    .foregroundStyle(selected ? .white : .primary)
+                    .lineLimit(1)
+                Text(item.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(selected ? .white.opacity(0.75) : .secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            if item.isDirectory {
+                Text("Folder")
+                    .font(.system(size: 10))
+                    .foregroundStyle(selected ? Color.white.opacity(0.7) : Color.secondary.opacity(0.7))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background {
+            if selected {
+                RoundedRectangle(cornerRadius: 10).fill(Color.accentColor.opacity(0.85))
+            }
+        }
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
+    }
+}
+
+struct SystemActionConfirmationView: View {
+    @ObservedObject var viewModel: SearchViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: viewModel.pendingSystemAction?.icon ?? "exclamationmark.triangle")
+                .font(.system(size: 42))
+                .foregroundStyle(.orange)
+            Text(viewModel.isExecutingSystemAction
+                 ? "Running \(viewModel.pendingSystemAction?.title ?? "System Action")…"
+                 : "Confirm \(viewModel.pendingSystemAction?.title ?? "System Action")")
+                .font(.system(size: 20, weight: .semibold))
+            Text(viewModel.isExecutingSystemAction
+                 ? "Ainto is asking macOS to perform this action."
+                 : "This action affects your current macOS session.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            if let error = viewModel.systemActionError {
+                Text(error)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            }
+            if viewModel.isExecutingSystemAction {
+                ProgressView().controlSize(.small)
+            } else {
+                HStack(spacing: 12) {
+                    Button("Cancel") { viewModel.cancelSystemAction() }
+                        .keyboardShortcut(.cancelAction)
+                    Button(viewModel.systemActionError == nil
+                           ? (viewModel.pendingSystemAction?.title ?? "Continue")
+                           : "Try Again", role: .destructive) {
+                        viewModel.confirmSystemAction()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+            Spacer()
+            Divider().opacity(0.3)
+            HStack {
+                Spacer()
+                if !viewModel.isExecutingSystemAction {
+                    KeyHint(keys: ["↵"], label: viewModel.systemActionError == nil ? "confirm" : "retry")
+                    KeyHint(keys: ["esc"], label: "cancel")
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 680, height: 300)
+    }
+}

--- a/AintoApp/Sources/Views/MainView.swift
+++ b/AintoApp/Sources/Views/MainView.swift
@@ -17,6 +17,10 @@ struct MainView: View {
                 SnippetView(viewModel: viewModel)
             case .aiCommands:
                 AICommandView(viewModel: viewModel)
+            case .fileSearch:
+                FileSearchView(viewModel: viewModel, service: viewModel.fileSearch)
+            case .systemConfirmation:
+                SystemActionConfirmationView(viewModel: viewModel)
             case .claude:
                 ClaudeView(viewModel: viewModel)
             }

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_body_length function_body_length cyclomatic_complexity identifier_name file_length
 import AppKit
 import SwiftUI
 
@@ -72,6 +73,8 @@ final class SearchPanel: NSPanel {
         viewModel.onGrabSelection = { [weak self] completion in
             self?.grabSelectionFromPreviousApp(completion: completion)
         }
+        viewModel.fileSearch.onOpen = { [weak self] in self?.hidePanel() }
+        viewModel.onSystemActionCompleted = { [weak self] in self?.hidePanel() }
 
         viewModel.loadAISettings()
     }
@@ -109,6 +112,7 @@ final class SearchPanel: NSPanel {
 
     func hidePanel() {
         hideActionPanel()
+        viewModel.prepareForPanelHide()
         orderOut(nil)
     }
 
@@ -190,8 +194,7 @@ final class SearchPanel: NSPanel {
         guard !actions.isEmpty else { return }
         actionSelectedIndex = 0
 
-        let title = viewModel.results.indices.contains(viewModel.selectedIndex)
-            ? viewModel.results[viewModel.selectedIndex].title : ""
+        let title = viewModel.currentActionTitle
 
         let panelView = ActionPanelView(
             title: title,
@@ -235,8 +238,7 @@ final class SearchPanel: NSPanel {
     func updateActionPanelSelection() {
         guard let window = actionWindow else { return }
         let actions = viewModel.currentActions
-        let title = viewModel.results.indices.contains(viewModel.selectedIndex)
-            ? viewModel.results[viewModel.selectedIndex].title : ""
+        let title = viewModel.currentActionTitle
 
         let panelView = ActionPanelView(
             title: title,

--- a/AintoApp/Sources/Views/SettingsView.swift
+++ b/AintoApp/Sources/Views/SettingsView.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length
 import SwiftUI
 import AppKit
 import AintoCore
@@ -14,6 +16,9 @@ struct SettingsView: View {
     @State private var claudeBinary: String = "claude"
     @State private var aiEnabled: Bool = true
     @State private var snippetsEnabled: Bool = true
+    @State private var fileSearchPaths: [String] = [NSHomeDirectory()]
+    @State private var fileSearchAllLocations = false
+    @State private var fileSearchIncludeHidden = false
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var selectedHotkey: String = "⌘ ⇧ Space"
     @State private var hasLoaded = false
@@ -26,6 +31,7 @@ struct SettingsView: View {
         case clipboard = "Clipboard"
         case ai = "AI"
         case snippets = "Snippets"
+        case fileSearch = "File Search"
         case data = "Data"
         case about = "About"
 
@@ -35,6 +41,7 @@ struct SettingsView: View {
             case .clipboard: return "doc.on.clipboard"
             case .ai: return "sparkle"
             case .snippets: return "text.quote"
+            case .fileSearch: return "doc.text.magnifyingglass"
             case .data: return "folder"
             case .about: return "info.circle"
             }
@@ -68,6 +75,7 @@ struct SettingsView: View {
                     case .clipboard: clipboardSection
                     case .ai: aiSection
                     case .snippets: snippetsSection
+                    case .fileSearch: fileSearchSection
                     case .data: dataSection
                     case .about: aboutSection
                     }
@@ -87,6 +95,9 @@ struct SettingsView: View {
         .onChange(of: claudeBinary) { _, _ in saveConfig() }
         .onChange(of: aiEnabled) { _, _ in saveConfig() }
         .onChange(of: snippetsEnabled) { _, _ in saveConfig() }
+        .onChange(of: fileSearchPaths) { _, _ in saveConfig() }
+        .onChange(of: fileSearchAllLocations) { _, _ in saveConfig() }
+        .onChange(of: fileSearchIncludeHidden) { _, _ in saveConfig() }
         .alert("Reset Rankings", isPresented: $showResetConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Reset", role: .destructive) {
@@ -331,6 +342,16 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - File Search
+
+    private var fileSearchSection: some View {
+        FileSearchSettingsView(
+            paths: $fileSearchPaths,
+            allLocations: $fileSearchAllLocations,
+            includeHidden: $fileSearchIncludeHidden
+        )
+    }
+
     // MARK: - Data
 
     private var dataSection: some View {
@@ -496,6 +517,9 @@ struct SettingsView: View {
         claudeBinary = config["claude_binary"] as? String ?? "claude"
         aiEnabled = config["ai_enabled"] as? Bool ?? true
         snippetsEnabled = config["snippets_enabled"] as? Bool ?? true
+        fileSearchPaths = config["file_search_paths"] as? [String] ?? [NSHomeDirectory()]
+        fileSearchAllLocations = config["file_search_all_locations"] as? Bool ?? false
+        fileSearchIncludeHidden = config["file_search_include_hidden"] as? Bool ?? false
         hasLoaded = true
     }
 
@@ -507,6 +531,9 @@ struct SettingsView: View {
             "claude_binary": claudeBinary,
             "ai_enabled": aiEnabled,
             "snippets_enabled": snippetsEnabled,
+            "file_search_paths": fileSearchPaths,
+            "file_search_all_locations": fileSearchAllLocations,
+            "file_search_include_hidden": fileSearchIncludeHidden,
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: config),
               let jsonStr = String(data: data, encoding: .utf8) else { return }

--- a/AintoApp/Tests/LauncherNavigationTests.swift
+++ b/AintoApp/Tests/LauncherNavigationTests.swift
@@ -39,4 +39,13 @@ final class LauncherNavigationTests: XCTestCase {
 
         XCTAssertEqual(viewModel.page, .clipboard)
     }
+
+    func testFileSearchSurvivesHidingThePanel() {
+        let viewModel = SearchViewModel()
+        viewModel.page = .fileSearch
+
+        viewModel.prepareForPanelHide()
+
+        XCTAssertEqual(viewModel.page, .fileSearch)
+    }
 }

--- a/AintoApp/Tests/LauncherNavigationTests.swift
+++ b/AintoApp/Tests/LauncherNavigationTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+#if SWIFT_PACKAGE
+@testable import AintoApp
+#else
+@testable import Ainto
+#endif
+
+@MainActor
+final class LauncherNavigationTests: XCTestCase {
+    func testPendingSystemActionDoesNotSurviveHidingThePanel() {
+        let viewModel = SearchViewModel()
+        viewModel.page = .systemConfirmation
+        viewModel.pendingSystemAction = .restart
+
+        viewModel.prepareForPanelHide()
+
+        // Reopening on a stale confirmation would leave Restart one Return away.
+        XCTAssertEqual(viewModel.page, .main)
+        XCTAssertNil(viewModel.pendingSystemAction)
+    }
+
+    func testConfirmationSurvivesWhileTheActionIsExecuting() {
+        let viewModel = SearchViewModel()
+        viewModel.page = .systemConfirmation
+        viewModel.pendingSystemAction = .restart
+        viewModel.isExecutingSystemAction = true
+
+        viewModel.prepareForPanelHide()
+
+        XCTAssertEqual(viewModel.page, .systemConfirmation)
+        XCTAssertEqual(viewModel.pendingSystemAction, .restart)
+    }
+
+    func testUnaffectedPagesAreLeftAlone() {
+        let viewModel = SearchViewModel()
+        viewModel.page = .clipboard
+
+        viewModel.prepareForPanelHide()
+
+        XCTAssertEqual(viewModel.page, .clipboard)
+    }
+}

--- a/AintoApp/Tests/SystemActionServiceTests.swift
+++ b/AintoApp/Tests/SystemActionServiceTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+#if SWIFT_PACKAGE
+@testable import AintoApp
+#else
+@testable import Ainto
+#endif
+
+final class SystemActionServiceTests: XCTestCase {
+    func testConfirmationPolicy() {
+        XCTAssertFalse(SystemAction.sleep.requiresConfirmation)
+        XCTAssertFalse(SystemAction.lockScreen.requiresConfirmation)
+        XCTAssertFalse(SystemAction.emptyTrash.requiresConfirmation)
+        XCTAssertTrue(SystemAction.logOut.requiresConfirmation)
+        XCTAssertTrue(SystemAction.restart.requiresConfirmation)
+        XCTAssertTrue(SystemAction.shutDown.requiresConfirmation)
+    }
+}

--- a/AintoApp/project.yml
+++ b/AintoApp/project.yml
@@ -63,6 +63,8 @@ targets:
       - sdk: Security.framework
       - sdk: SystemConfiguration.framework
       - sdk: ServiceManagement.framework
+      - sdk: QuickLookUI.framework
+      - sdk: UniformTypeIdentifiers.framework
     settings:
       base:
         GENERATE_INFOPLIST_FILE: NO

--- a/ainto-core/src/config.rs
+++ b/ainto-core/src/config.rs
@@ -18,6 +18,12 @@ pub struct Config {
     /// Master switch for all AI-related features in the UI.
     /// When false, the launcher hides every AI surface.
     pub ai_enabled: bool,
+    /// Spotlight folders used by File Search. Empty values are ignored.
+    pub file_search_paths: Vec<String>,
+    /// Search the entire local Spotlight index instead of selected folders.
+    pub file_search_all_locations: bool,
+    /// Include hidden Spotlight results.
+    pub file_search_include_hidden: bool,
 }
 
 impl Default for Config {
@@ -28,6 +34,11 @@ impl Default for Config {
             claude_binary: "claude".to_string(),
             snippets_enabled: true,
             ai_enabled: true,
+            file_search_paths: dirs::home_dir()
+                .map(|path| vec![path.to_string_lossy().into_owned()])
+                .unwrap_or_default(),
+            file_search_all_locations: false,
+            file_search_include_hidden: false,
         }
     }
 }
@@ -68,4 +79,43 @@ impl Config {
 pub fn config_dir() -> Result<PathBuf, Error> {
     let home = dirs::home_dir().ok_or(Error::NoHomeDir)?;
     Ok(home.join(".config").join("ainto"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_config_receives_file_search_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+clipboard_max_items = 100
+clipboard_max_image_items = 25
+claude_binary = "claude"
+snippets_enabled = true
+ai_enabled = true
+"#,
+        )
+        .unwrap();
+
+        assert!(!config.file_search_all_locations);
+        assert!(!config.file_search_include_hidden);
+        assert_eq!(
+            config.file_search_paths,
+            Config::default().file_search_paths
+        );
+    }
+
+    #[test]
+    fn file_search_settings_round_trip() {
+        let config = Config {
+            file_search_paths: vec!["/Users/example/Documents".into()],
+            file_search_all_locations: true,
+            file_search_include_hidden: true,
+            ..Config::default()
+        };
+        let encoded = toml::to_string(&config).unwrap();
+        let decoded: Config = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded, config);
+    }
 }


### PR DESCRIPTION
Add dedicated Spotlight file search and a fixed set of macOS system
 actions to the launcher.

   I have tested the features locally, but this is a relatively large
 launcher extension and may need adjustment to fit the project roadmap.

   What changed

   - Add a dedicated File Search page entered through `f` or `file search`.
   - Search the configured folders through the macOS Spotlight index.
   - Add configurable search folders, hidden-file handling, and an optional
 whole-Mac scope.
   - Add a shortcut to Full Disk Access settings.
   - Exclude application bundles and executable files from file results.
   - Add file actions for:
     - Open
     - Show in Finder
     - Quick Look
     - Copy Path
     - Open With
   - Add fixed system actions for:
     - Sleep
     - Lock Screen
     - Log Out
     - Restart
     - Shut Down
     - Empty Trash
   - Require an Ainto confirmation step for Log Out, Restart, and Shut Down.
   - Keep system execution restricted to a fixed allowlist without accepting
 arbitrary shell commands.
   - Add the Apple Events usage description required for Finder and System
 Events automation.

   Backward compatibility

   - Existing config files continue to load with the user's home directory as
 the default File Search scope.
   - Existing app search, clipboard history, snippets, and AI command
 behavior are unchanged.

   Validation

   - `cargo test --release` — 16 tests passed
   - `swift test -c release` — 1 test passed
   - Unsigned Xcode Release build succeeded
   - `git diff --check`