### PR TITLE
Add global launcher aliases

### DIFF
--- a/AintoApp/AintoCoreBridge/ainto_core.h
+++ b/AintoApp/AintoCoreBridge/ainto_core.h
@@ -27,6 +27,9 @@ const char* rc_discover_apps(bool store_icons);
 /// Search apps by query, returns JSON array string
 const char* rc_search_apps(const char* query);
 
+/// Get every indexed app, including stable bundle identifiers.
+const char* rc_get_all_apps(void);
+
 /// Get top-ranked (most used) apps, returns JSON array string
 const char* rc_get_top_apps(uint64_t limit);
 
@@ -96,6 +99,16 @@ int32_t rc_snippets_save(const char* json);
 /// Expand a snippet's text with placeholders resolved
 /// clipboard_text can be NULL
 const char* rc_snippet_expand(const char* expansion_text, const char* clipboard_text);
+
+// ============================================================
+// Global Aliases
+// ============================================================
+
+/// Load aliases as JSON array.
+const char* rc_aliases_load(void);
+
+/// Validate and save aliases from a JSON array. Returns 0 on success.
+int32_t rc_aliases_save(const char* json);
 
 // ============================================================
 // AI Commands

--- a/AintoApp/Package.swift
+++ b/AintoApp/Package.swift
@@ -35,7 +35,14 @@ let package = Package(
                 .linkedFramework("AppKit"),
                 .linkedFramework("Security"),
                 .linkedFramework("SystemConfiguration"),
+                .linkedFramework("QuickLookUI"),
+                .linkedFramework("UniformTypeIdentifiers"),
             ]
+        ),
+        .testTarget(
+            name: "AintoAppTests",
+            dependencies: ["AintoApp"],
+            path: "Tests"
         ),
     ]
 )

--- a/AintoApp/Resources/Ainto-Debug.entitlements
+++ b/AintoApp/Resources/Ainto-Debug.entitlements
@@ -6,5 +6,7 @@
     <false/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
 </dict>
 </plist>

--- a/AintoApp/Resources/Ainto.entitlements
+++ b/AintoApp/Resources/Ainto.entitlements
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <false/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
 </dict>
 </plist>

--- a/AintoApp/Resources/Info.plist
+++ b/AintoApp/Resources/Info.plist
@@ -34,6 +34,8 @@
     <string></string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Ainto uses macOS automation to perform the system actions you explicitly run.</string>
 
     <!-- Sparkle Auto-Update Configuration -->
     <key>SUFeedURL</key>

--- a/AintoApp/Sources/App/AppDelegate.swift
+++ b/AintoApp/Sources/App/AppDelegate.swift
@@ -72,6 +72,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.openSettings()
         })
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(aliasesDidChange),
+            name: .aliasesDidChange,
+            object: nil
+        )
+
         // Watch ~/.config/ainto/ for external file changes (e.g. manual TOML edits)
         watchConfigDirectory()
     }
@@ -79,7 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Monitor config files for external changes and reload automatically.
     private func watchConfigDirectory() {
         let configDir = NSHomeDirectory() + "/.config/ainto"
-        let files = ["snippets.toml", "ai-commands.toml", "config.toml"]
+        let files = ["snippets.toml", "ai-commands.toml", "aliases.toml", "config.toml"]
 
         for file in files {
             let path = configDir + "/" + file
@@ -97,6 +104,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // Covers both the Settings toggle (saved via rc_config_save)
                     // and manual TOML edits.
                     self?.applySnippetsEnabled()
+                } else if file == "aliases.toml" {
+                    self?.searchPanel?.viewModel.reloadAliases()
                 } else {
                     self?.searchPanel?.viewModel.loadSnippets()
                     self?.searchPanel?.viewModel.loadAICommands()
@@ -107,6 +116,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             source.resume()
             configWatcherSources.append(source)
         }
+    }
+
+    @objc private func aliasesDidChange() {
+        searchPanel?.viewModel.reloadAliases()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/AintoApp/Sources/Bridge/SearchViewModel+Aliases.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel+Aliases.swift
@@ -1,0 +1,119 @@
+import AppKit
+import Foundation
+import AintoCore
+
+extension SearchViewModel {
+    nonisolated static func appTargetRef(bundleID: String?, path: String) -> LauncherTargetRef {
+        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        if let bundleID, !bundleID.isEmpty {
+            // Bundle IDs are not unique when multiple copies of an app are installed.
+            return LauncherTargetRef(kind: .app, id: "bundle:\(bundleID)|path:\(standardizedPath)")
+        }
+        return LauncherTargetRef(kind: .app, id: "path:\(standardizedPath)")
+    }
+
+    func resolvedAliasResult(for query: String) -> SearchResult? {
+        let normalized = AliasStore.normalize(query)
+        guard !normalized.isEmpty,
+              let entry = aliases.first(where: { AliasStore.normalize($0.alias) == normalized }),
+              var result = result(for: entry.target)
+        else { return nil }
+        result.subtitle = "Alias: \(entry.alias) • \(result.subtitle)"
+        result.score = 10_000
+        return result
+    }
+
+    private func result(for target: LauncherTargetRef) -> SearchResult? {
+        switch target.kind {
+        case .app:
+            return appResult(targetID: target.id)
+        case .aiCommand:
+            guard aiEnabled,
+                  let command = AICommand.loadAll().first(where: { $0.id == target.id })
+            else { return nil }
+            var result = SearchResult(
+                title: command.name,
+                subtitle: "AI Command",
+                icon: nil,
+                systemIcon: command.icon,
+                targetRef: target
+            ) { [weak self] in
+                self?.incrementCommandRanking(command)
+                self?.executeAICommand(command)
+            }
+            result.actions = aiCommandActions(for: command)
+            return result
+        case .snippet:
+            return snippetResult(targetID: target.id)
+        case .launcherCommand:
+            switch target.id {
+            case "file-search":
+                return fileSearchCommandResult(score: 0)
+            case "clipboard-history":
+                return SearchResult(
+                    title: "Clipboard History",
+                    subtitle: "Command",
+                    icon: nil,
+                    systemIcon: "doc.on.clipboard",
+                    targetRef: target
+                ) { [weak self] in self?.goToClipboard() }
+            default:
+                return nil
+            }
+        case .systemAction:
+            guard let action = SystemAction(rawValue: target.id) else { return nil }
+            return systemActionResult(action, score: 0)
+        }
+    }
+
+    private func appResult(targetID: String) -> SearchResult? {
+        guard let cString = rc_get_all_apps() else { return nil }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let entry = entries.first(where: { entry in
+                  let path = entry["path"] as? String ?? ""
+                  let bundleID = entry["bundle_id"] as? String
+                  return Self.appTargetRef(bundleID: bundleID, path: path).id == targetID
+              })
+        else { return nil }
+
+        let name = entry["display_name"] as? String ?? ""
+        let path = entry["path"] as? String ?? ""
+        var result = SearchResult(
+            title: name,
+            subtitle: "Application",
+            icon: loadAppIcon(path: path),
+            systemIcon: "app.fill",
+            targetRef: LauncherTargetRef(kind: .app, id: targetID)
+        ) {
+            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+            rc_update_ranking(path)
+        }
+        result.actions = Self.appActions(path: path)
+        return result
+    }
+
+    private func snippetResult(targetID: String) -> SearchResult? {
+        guard let cString = rc_snippets_load() else { return nil }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let snippet = entries.first(where: { $0["id"] as? String == targetID })
+        else { return nil }
+        let name = snippet["name"] as? String ?? ""
+        let keyword = snippet["keyword"] as? String ?? ""
+        let expansion = snippet["expansion"] as? String ?? ""
+        return SearchResult(
+            title: name,
+            subtitle: "Snippet: \(keyword)",
+            icon: nil,
+            systemIcon: "doc.text.fill",
+            targetRef: LauncherTargetRef(kind: .snippet, id: targetID)
+        ) { [weak self] in
+            self?.expandAndPasteSnippet(expansion)
+        }
+    }
+}

--- a/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Foundation
+
+extension SearchViewModel {
+    func fileSearchCommandResult(score: Int) -> SearchResult {
+        SearchResult(
+            title: "File Search",
+            subtitle: "Search files and folders with Spotlight",
+            icon: nil,
+            systemIcon: "doc.text.magnifyingglass",
+            score: score
+        ) { [weak self] in
+            self?.goToFileSearch()
+        }
+    }
+
+    func systemActionResult(_ action: SystemAction, score: Int) -> SearchResult {
+        SearchResult(
+            title: action.title,
+            subtitle: action.requiresConfirmation ? "System Action • Confirmation required" : "System Action",
+            icon: nil,
+            systemIcon: action.icon,
+            score: score
+        ) { [weak self] in
+            self?.requestSystemAction(action)
+        }
+    }
+
+    func requestSystemAction(_ action: SystemAction) {
+        systemActionError = nil
+        pendingSystemAction = action
+        if action.requiresConfirmation {
+            page = .systemConfirmation
+        } else {
+            // Keep the panel visible so failures from immediate actions are shown.
+            page = .systemConfirmation
+            executeSystemAction(action)
+        }
+    }
+
+    func confirmSystemAction() {
+        guard let action = pendingSystemAction else {
+            goBack()
+            return
+        }
+        executeSystemAction(action)
+    }
+
+    func cancelSystemAction() {
+        guard !isExecutingSystemAction else { return }
+        pendingSystemAction = nil
+        systemActionError = nil
+        page = .main
+        focusFilterField()
+    }
+
+    private func executeSystemAction(_ action: SystemAction) {
+        guard !isExecutingSystemAction else { return }
+        isExecutingSystemAction = true
+        systemActionError = nil
+        Task { [weak self] in
+            let errorMessage = await Task.detached { () -> String? in
+                do {
+                    try SystemActionService.execute(action)
+                    return nil
+                } catch {
+                    return error.localizedDescription
+                }
+            }.value
+            guard let self else { return }
+            isExecutingSystemAction = false
+            if let errorMessage {
+                pendingSystemAction = action
+                systemActionError = errorMessage
+                page = .systemConfirmation
+            } else {
+                pendingSystemAction = nil
+                page = .main
+                onSystemActionCompleted?()
+            }
+        }
+    }
+}

--- a/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel+LauncherActions.swift
@@ -8,7 +8,8 @@ extension SearchViewModel {
             subtitle: "Search files and folders with Spotlight",
             icon: nil,
             systemIcon: "doc.text.magnifyingglass",
-            score: score
+            score: score,
+            targetRef: LauncherTargetRef(kind: .launcherCommand, id: "file-search")
         ) { [weak self] in
             self?.goToFileSearch()
         }
@@ -20,7 +21,8 @@ extension SearchViewModel {
             subtitle: action.requiresConfirmation ? "System Action • Confirmation required" : "System Action",
             icon: nil,
             systemIcon: action.icon,
-            score: score
+            score: score,
+            targetRef: LauncherTargetRef(kind: .systemAction, id: action.id)
         ) { [weak self] in
             self?.requestSystemAction(action)
         }

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -25,7 +25,7 @@ struct AICommand: Identifiable {
 
         return entries.map { entry in
             AICommand(
-                id: entry["name"] as? String ?? UUID().uuidString,
+                id: entry["id"] as? String ?? UUID().uuidString,
                 name: entry["name"] as? String ?? "",
                 icon: entry["icon"] as? String ?? "sparkle",
                 prompt: entry["prompt"] as? String ?? ""
@@ -129,6 +129,11 @@ enum SearchMode: Equatable {
     case claude  // Tab: ask Claude
 }
 
+enum SelectionCaptureResult {
+    case success(String)
+    case failure(String)
+}
+
 /// An action available for a search result.
 struct ActionItem: Identifiable {
     let id = UUID()
@@ -143,10 +148,11 @@ struct ActionItem: Identifiable {
 struct SearchResult: Identifiable {
     let id = UUID()
     let title: String
-    let subtitle: String
+    var subtitle: String
     let icon: NSImage?
     let systemIcon: String? // fallback SF Symbol name
     var score: Int = 0 // higher = better match, used for unified sorting
+    var targetRef: LauncherTargetRef? = nil
     let action: () -> Void
     var actions: [ActionItem] = [] // Cmd+K to show
 
@@ -297,6 +303,7 @@ final class SearchViewModel: ObservableObject {
     @Published var pendingSystemAction: SystemAction?
     @Published var systemActionError: String?
     @Published var isExecutingSystemAction = false
+    var aliases: [LauncherAlias] = []
     var onSystemActionCompleted: (() -> Void)?
 
     // Claude state
@@ -448,6 +455,10 @@ final class SearchViewModel: ObservableObject {
         focusFilterField()
     }
 
+    func reloadAliases() {
+        aliases = AliasStore.load()
+    }
+
     func prepareForPanelHide() {
         guard page == .fileSearch else { return }
         fileSearch.clear()
@@ -520,6 +531,7 @@ final class SearchViewModel: ObservableObject {
                 appResults = entries.prefix(8).map { entry in
                     let name = entry["display_name"] as? String ?? ""
                     let path = entry["path"] as? String ?? ""
+                    let bundleID = entry["bundle_id"] as? String
                     let ranking = entry["ranking"] as? Int ?? 0
                     let icon = self.loadAppIcon(path: path)
                     var result = SearchResult(
@@ -527,7 +539,8 @@ final class SearchViewModel: ObservableObject {
                         subtitle: "Application",
                         icon: icon,
                         systemIcon: "app.fill",
-                        score: fuzzyScore(query, name) + ranking
+                        score: fuzzyScore(query, name) + ranking,
+                        targetRef: Self.appTargetRef(bundleID: bundleID, path: path)
                     ) {
                         NSWorkspace.shared.open(URL(fileURLWithPath: path))
                         rc_update_ranking(path)
@@ -557,11 +570,13 @@ final class SearchViewModel: ObservableObject {
                         let name = snippet["name"] as? String ?? ""
                         let keyword = snippet["keyword"] as? String ?? ""
                         let expansion = snippet["expansion"] as? String ?? ""
+                        let id = snippet["id"] as? String ?? ""
                         return SearchResult(
                             title: name,
                             subtitle: "Snippet: \(keyword)",
                             icon: nil,
-                            systemIcon: "doc.text.fill"
+                            systemIcon: "doc.text.fill",
+                            targetRef: LauncherTargetRef(kind: .snippet, id: id)
                         ) { [weak self] in
                             self?.expandAndPasteSnippet(expansion)
                         }
@@ -579,20 +594,21 @@ final class SearchViewModel: ObservableObject {
             let matchingAICommands = AICommand.loadAll().filter { cmd in
                 fuzzyMatch(q, cmd.name)
             }
-            let rankedAICommands = matchingAICommands.sorted { a, b in
-                self.commandRanking(for: a.name) > self.commandRanking(for: b.name)
+            let rankedAICommands = matchingAICommands.sorted { first, second in
+                self.commandRanking(for: first) > self.commandRanking(for: second)
             }
             for cmd in rankedAICommands.prefix(6) {
                 let command = cmd
-                let cmdScore = fuzzyScore(q, command.name) + self.commandRanking(for: command.name)
+                let cmdScore = fuzzyScore(q, command.name) + self.commandRanking(for: command)
                 var result = SearchResult(
                     title: command.name,
                     subtitle: "AI Command",
                     icon: nil,
                     systemIcon: command.icon,
-                    score: cmdScore
+                    score: cmdScore,
+                    targetRef: LauncherTargetRef(kind: .aiCommand, id: command.id)
                 ) { [weak self] in
-                    self?.incrementCommandRanking(command.name)
+                    self?.incrementCommandRanking(command)
                     self?.executeAICommand(command)
                 }
                 result.actions = aiCommandActions(for: command)
@@ -632,7 +648,8 @@ final class SearchViewModel: ObservableObject {
                 subtitle: "Command",
                 icon: nil,
                 systemIcon: "doc.on.clipboard",
-                score: fuzzyScore(query, "Clipboard History") + commandRanking(for: "Clipboard History")
+                score: fuzzyScore(query, "Clipboard History") + commandRanking(for: "Clipboard History"),
+                targetRef: LauncherTargetRef(kind: .launcherCommand, id: "clipboard-history")
             ) { [weak self] in
                 self?.incrementCommandRanking("Clipboard History")
                 self?.goToClipboard()
@@ -649,6 +666,12 @@ final class SearchViewModel: ObservableObject {
         }
 
         var allResults = appResults + commandResults + snippetResults
+        if let aliasResult = resolvedAliasResult(for: query) {
+            if let target = aliasResult.targetRef {
+                allResults.removeAll { $0.targetRef == target }
+            }
+            allResults.append(aliasResult)
+        }
         allResults.sort { $0.score > $1.score }
         results = Array(allResults.prefix(20))
         selectedIndex = 0
@@ -918,7 +941,7 @@ final class SearchViewModel: ObservableObject {
 
     /// Expand a snippet's placeholders, put the result on the pasteboard,
     /// and paste it into the frontmost app.
-    private func expandAndPasteSnippet(_ expansion: String) {
+    func expandAndPasteSnippet(_ expansion: String) {
         let clipboardText = NSPasteboard.general.string(forType: .string)
         guard let cStr = rc_snippet_expand(expansion, clipboardText) else { return }
         let expanded = String(cString: cStr)
@@ -946,6 +969,7 @@ final class SearchViewModel: ObservableObject {
               let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
         aiEnabled = config["ai_enabled"] as? Bool ?? true
         claudeBinary = (config["claude_binary"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "claude"
+        reloadAliases()
         fileSearch.reloadConfiguration()
         exitAISurfacesIfDisabled()
     }
@@ -968,7 +992,7 @@ final class SearchViewModel: ObservableObject {
 
     func saveAICommands() {
         let jsonArray: [[String: Any]] = aiCommands.map { cmd in
-            ["name": cmd.name, "icon": cmd.icon, "prompt": cmd.prompt]
+            ["id": cmd.id, "name": cmd.name, "icon": cmd.icon, "prompt": cmd.prompt]
         }
         guard let data = try? JSONSerialization.data(withJSONObject: jsonArray),
               let jsonStr = String(data: data, encoding: .utf8) else { return }
@@ -1000,10 +1024,6 @@ final class SearchViewModel: ObservableObject {
         } else {
             aiCommands.append(editing)
         }
-        // Update id to match name (used as stable identifier)
-        if let idx = aiCommands.firstIndex(where: { $0.id == editing.id }) {
-            aiCommands[idx].id = editing.name
-        }
         saveAICommands()
         isEditingAICommand = false
         editingAICommand = nil
@@ -1024,7 +1044,7 @@ final class SearchViewModel: ObservableObject {
         }
     }
 
-    private func aiCommandActions(for command: AICommand) -> [ActionItem] {
+    func aiCommandActions(for command: AICommand) -> [ActionItem] {
         [
             ActionItem(title: "Edit", icon: "pencil", shortcut: nil, keepPanel: true) { [weak self] in
                 self?.goToAICommands()
@@ -1129,12 +1149,14 @@ final class SearchViewModel: ObservableObject {
                 for entry in entries {
                     let name = entry["display_name"] as? String ?? ""
                     let path = entry["path"] as? String ?? ""
+                    let bundleID = entry["bundle_id"] as? String
                     let icon = self.loadAppIcon(path: path)
                     var result = SearchResult(
                         title: name,
                         subtitle: "Application",
                         icon: icon,
-                        systemIcon: "app.fill"
+                        systemIcon: "app.fill",
+                        targetRef: Self.appTargetRef(bundleID: bundleID, path: path)
                     ) {
                         NSWorkspace.shared.open(URL(fileURLWithPath: path))
                         rc_update_ranking(path)
@@ -1150,7 +1172,8 @@ final class SearchViewModel: ObservableObject {
             title: "Clipboard History",
             subtitle: "Command",
             icon: nil,
-            systemIcon: "doc.on.clipboard"
+            systemIcon: "doc.on.clipboard",
+            targetRef: LauncherTargetRef(kind: .launcherCommand, id: "clipboard-history")
         ) { [weak self] in self?.goToClipboard() })
 
         results.append(fileSearchCommandResult(score: 0))
@@ -1173,8 +1196,8 @@ final class SearchViewModel: ObservableObject {
 
             // AI Commands — sorted by usage, top 4
             let aiCommands = AICommand.loadAll()
-            let sorted = aiCommands.sorted { a, b in
-                commandRanking(for: a.name) > commandRanking(for: b.name)
+            let sorted = aiCommands.sorted { first, second in
+                commandRanking(for: first) > commandRanking(for: second)
             }
             for cmd in sorted.prefix(4) {
                 let command = cmd
@@ -1182,9 +1205,10 @@ final class SearchViewModel: ObservableObject {
                     title: command.name,
                     subtitle: "AI Command",
                     icon: nil,
-                    systemIcon: command.icon
+                    systemIcon: command.icon,
+                    targetRef: LauncherTargetRef(kind: .aiCommand, id: command.id)
                 ) { [weak self] in
-                    self?.incrementCommandRanking(command.name)
+                    self?.incrementCommandRanking(command)
                     self?.executeAICommand(command)
                 }
                 result.actions = aiCommandActions(for: command)
@@ -1198,12 +1222,23 @@ final class SearchViewModel: ObservableObject {
     // MARK: - AI Commands
 
     /// Callback to grab selection from previous app (set by SearchPanel)
-    var onGrabSelection: ((@escaping (String) -> Void) -> Void)?
+    var onGrabSelection: ((@MainActor @escaping (SelectionCaptureResult) -> Void) -> Void)?
 
     func executeAICommand(_ command: AICommand) {
         // Ask the panel to hide, grab selection from previous app, then proceed
-        onGrabSelection? { [weak self] selectedText in
+        onGrabSelection? { [weak self] result in
             guard let self else { return }
+
+            let selectedText: String
+            switch result {
+            case .success(let text):
+                selectedText = text
+            case .failure(let message):
+                self.searchMode = .claude
+                self.claudeMessages.append(ClaudeMessage(role: .assistant, text: message))
+                self.page = .claude
+                return
+            }
 
             guard !selectedText.isEmpty else {
                 self.searchMode = .claude
@@ -1356,9 +1391,17 @@ final class SearchViewModel: ObservableObject {
         let _ = rc_increment_ranking(key)
     }
 
+    func incrementCommandRanking(_ command: AICommand) {
+        let _ = rc_increment_ranking("cmd-id:\(command.id)")
+    }
+
     func commandRanking(for name: String) -> Int {
         let key = "cmd:\(name)"
         return Int(rc_get_ranking(key))
+    }
+
+    func commandRanking(for command: AICommand) -> Int {
+        max(Int(rc_get_ranking("cmd-id:\(command.id)")), commandRanking(for: command.name))
     }
 
     // MARK: - Focus
@@ -1371,7 +1414,11 @@ final class SearchViewModel: ObservableObject {
         func tryFocus(attempts: Int) {
             guard attempts > 0 else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                if let window = NSApp.keyWindow,
+                // Alias fields in Settings can remain the key window. Always
+                // focus the visible launcher panel instead of NSApp.keyWindow.
+                if let window = NSApp.windows
+                    .compactMap({ $0 as? SearchPanel })
+                    .first(where: { $0.isVisible }),
                    let textField = Self.findTextField(in: window.contentView) {
                     window.makeFirstResponder(textField)
                     completion?()
@@ -1398,7 +1445,7 @@ final class SearchViewModel: ObservableObject {
 
     // MARK: - Private
 
-    private func loadAppIcon(path: String) -> NSImage? {
+    func loadAppIcon(path: String) -> NSImage? {
         if let cached = iconCache[path] {
             return cached
         }

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length cyclomatic_complexity
 import AppKit
 import Foundation
 import AintoCore
@@ -118,6 +119,8 @@ enum LauncherPage: Equatable {
     case clipboard
     case snippets
     case aiCommands
+    case fileSearch
+    case systemConfirmation
     case claude
 }
 
@@ -290,6 +293,12 @@ final class SearchViewModel: ObservableObject {
     @Published var page: LauncherPage = .main
     @Published var searchMode: SearchMode = .apps
 
+    let fileSearch = FileSearchService()
+    @Published var pendingSystemAction: SystemAction?
+    @Published var systemActionError: String?
+    @Published var isExecutingSystemAction = false
+    var onSystemActionCompleted: (() -> Void)?
+
     // Claude state
     @Published var claudeMessages: [ClaudeMessage] = []
     @Published var claudeIsStreaming = false
@@ -432,7 +441,25 @@ final class SearchViewModel: ObservableObject {
         focusFilterField()
     }
 
+    func goToFileSearch() {
+        page = .fileSearch
+        fileSearch.clear()
+        fileSearch.reloadConfiguration()
+        focusFilterField()
+    }
+
+    func prepareForPanelHide() {
+        guard page == .fileSearch else { return }
+        fileSearch.clear()
+        page = .main
+        searchMode = .apps
+        query = ""
+        selectedIndex = 0
+        results = buildDefaultResults()
+    }
+
     func goBack() {
+        if page == .systemConfirmation && isExecutingSystemAction { return }
         if page == .claude {
             claudeCancel()
             claudeMessages.removeAll()
@@ -442,6 +469,11 @@ final class SearchViewModel: ObservableObject {
             cancelEditingAICommand()
             return
         }
+        if page == .fileSearch {
+            fileSearch.clear()
+        }
+        pendingSystemAction = nil
+        systemActionError = nil
         clipboardFilter = "" // didSet handles cancel + debouncedClipboardFilter
         page = .main
         searchMode = .apps
@@ -608,6 +640,14 @@ final class SearchViewModel: ObservableObject {
             commandResults.append(r)
         }
 
+        if q == "f" || fuzzyMatch(q, "file search") {
+            commandResults.append(fileSearchCommandResult(score: q == "f" ? 300 : fuzzyScore(q, "File Search")))
+        }
+
+        for action in SystemAction.allCases where fuzzyMatch(q, action.title) {
+            commandResults.append(systemActionResult(action, score: fuzzyScore(q, action.title)))
+        }
+
         var allResults = appResults + commandResults + snippetResults
         allResults.sort { $0.score > $1.score }
         results = Array(allResults.prefix(20))
@@ -629,11 +669,13 @@ final class SearchViewModel: ObservableObject {
             let count = filteredAICommands.count
             guard count > 0 else { return }
             aiCommandSelectedIndex = max(0, min(aiCommandSelectedIndex + offset, count - 1))
+        case .fileSearch:
+            fileSearch.moveSelection(by: offset)
         case .main:
             guard !results.isEmpty else { return }
             selectedIndex = max(0, min(selectedIndex + offset, results.count - 1))
-        case .claude:
-            break // no list navigation in Claude view
+        case .systemConfirmation, .claude:
+            break // no list navigation on these pages
         }
     }
 
@@ -645,6 +687,10 @@ final class SearchViewModel: ObservableObject {
             expandSelectedSnippet()
         case .aiCommands:
             executeSelectedAICommand()
+        case .fileSearch:
+            fileSearch.openSelected()
+        case .systemConfirmation:
+            confirmSystemAction()
         case .main:
             guard selectedIndex < results.count else { return }
             results[selectedIndex].action()
@@ -900,6 +946,7 @@ final class SearchViewModel: ObservableObject {
               let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
         aiEnabled = config["ai_enabled"] as? Bool ?? true
         claudeBinary = (config["claude_binary"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "claude"
+        fileSearch.reloadConfiguration()
         exitAISurfacesIfDisabled()
     }
 
@@ -1007,8 +1054,23 @@ final class SearchViewModel: ObservableObject {
         case .main:
             guard selectedIndex < results.count else { return [] }
             return results[selectedIndex].actions
+        case .fileSearch:
+            guard fileSearch.results.indices.contains(fileSearch.selectedIndex) else { return [] }
+            return fileSearch.actions(for: fileSearch.results[fileSearch.selectedIndex])
         default:
             return []
+        }
+    }
+
+    var currentActionTitle: String {
+        switch page {
+        case .main:
+            return results.indices.contains(selectedIndex) ? results[selectedIndex].title : ""
+        case .fileSearch:
+            return fileSearch.results.indices.contains(fileSearch.selectedIndex)
+                ? fileSearch.results[fileSearch.selectedIndex].title : ""
+        default:
+            return ""
         }
     }
 
@@ -1090,6 +1152,8 @@ final class SearchViewModel: ObservableObject {
             icon: nil,
             systemIcon: "doc.on.clipboard"
         ) { [weak self] in self?.goToClipboard() })
+
+        results.append(fileSearchCommandResult(score: 0))
 
         results.append(SearchResult(
             title: "Snippets",

--- a/AintoApp/Sources/Services/AliasService.swift
+++ b/AintoApp/Sources/Services/AliasService.swift
@@ -1,0 +1,82 @@
+import Foundation
+import AintoCore
+
+extension Notification.Name {
+    static let aliasesDidChange = Notification.Name("app.ainto.aliasesDidChange")
+}
+
+enum LauncherTargetKind: String, Codable, CaseIterable {
+    case app
+    case aiCommand = "ai_command"
+    case snippet
+    case launcherCommand = "launcher_command"
+    case systemAction = "system_action"
+}
+
+struct LauncherTargetRef: Hashable, Codable {
+    let kind: LauncherTargetKind
+    let id: String
+}
+
+struct LauncherAlias: Codable, Identifiable, Hashable {
+    var alias: String
+    var targetType: LauncherTargetKind
+    var targetID: String
+
+    var id: String { AliasStore.normalize(alias) }
+    var target: LauncherTargetRef { LauncherTargetRef(kind: targetType, id: targetID) }
+
+    enum CodingKeys: String, CodingKey {
+        case alias
+        case targetType = "target_type"
+        case targetID = "target_id"
+    }
+}
+
+struct AliasTargetOption: Identifiable, Hashable {
+    let ref: LauncherTargetRef
+    let title: String
+    let detail: String
+    var id: String { "\(ref.kind.rawValue):\(ref.id)" }
+}
+
+enum AliasStore {
+    static func normalize(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .precomposedStringWithCompatibilityMapping
+            .folding(options: [.caseInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .precomposedStringWithCompatibilityMapping
+    }
+
+    static func load() -> [LauncherAlias] {
+        guard let cString = rc_aliases_load() else { return [] }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([LauncherAlias].self, from: data)) ?? []
+    }
+
+    static func validate(_ aliases: [LauncherAlias]) -> String? {
+        var used = Set<String>()
+        for entry in aliases {
+            let normalized = normalize(entry.alias)
+            if normalized.isEmpty { return "Alias cannot be empty." }
+            if !used.insert(normalized).inserted {
+                return "The alias ‘\(entry.alias.trimmingCharacters(in: .whitespacesAndNewlines))’ is already in use."
+            }
+        }
+        return nil
+    }
+
+    @discardableResult
+    static func save(_ aliases: [LauncherAlias]) -> Bool {
+        guard validate(aliases) == nil,
+              let data = try? JSONEncoder().encode(aliases),
+              let json = String(data: data, encoding: .utf8)
+        else { return false }
+        guard rc_aliases_save(json) == 0 else { return false }
+        NotificationCenter.default.post(name: .aliasesDidChange, object: nil)
+        return true
+    }
+}

--- a/AintoApp/Sources/Services/FileSearchService.swift
+++ b/AintoApp/Sources/Services/FileSearchService.swift
@@ -1,0 +1,287 @@
+import AppKit
+import Foundation
+import AintoCore
+import QuickLookUI
+import UniformTypeIdentifiers
+
+struct FileSearchItem: Identifiable, Hashable {
+    let url: URL
+    let isDirectory: Bool
+
+    var id: String { url.path }
+    var title: String { url.lastPathComponent }
+    var subtitle: String { url.deletingLastPathComponent().path }
+    var icon: NSImage { NSWorkspace.shared.icon(forFile: url.path) }
+}
+
+/// Owns one cancellable Spotlight query at a time and publishes only results
+/// from the latest generation.
+@MainActor
+final class FileSearchService: NSObject, ObservableObject {
+    @Published var queryText: String = "" {
+        didSet { scheduleSearch() }
+    }
+    @Published private(set) var results: [FileSearchItem] = []
+    @Published private(set) var isSearching = false
+    @Published private(set) var errorMessage: String?
+    @Published var selectedIndex = 0
+    var onOpen: (() -> Void)?
+
+    private var metadataQuery: NSMetadataQuery?
+    private var debounceWork: DispatchWorkItem?
+    private var searchPaths: [String] = []
+    private var allLocations = false
+    private var includeHidden = false
+    private var configurationLoaded = false
+
+    func reloadConfiguration() {
+        guard let cString = rc_config_load() else {
+            configurationLoaded = false
+            searchPaths = []
+            allLocations = false
+            errorMessage = "File Search settings could not be loaded. Check config.toml in Settings."
+            return
+        }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            configurationLoaded = false
+            searchPaths = []
+            allLocations = false
+            errorMessage = "File Search settings could not be loaded. Check config.toml in Settings."
+            return
+        }
+        searchPaths = (config["file_search_paths"] as? [String])?
+            .map { URL(fileURLWithPath: $0).standardizedFileURL.resolvingSymlinksInPath().path }
+            .filter { !$0.isEmpty } ?? []
+        allLocations = config["file_search_all_locations"] as? Bool ?? false
+        includeHidden = config["file_search_include_hidden"] as? Bool ?? false
+        configurationLoaded = true
+        errorMessage = allLocations || !searchPaths.isEmpty
+            ? nil
+            : "Choose at least one File Search folder in Settings."
+    }
+
+    func clear() {
+        queryText = ""
+        cancelQuery()
+        results = []
+        selectedIndex = 0
+        errorMessage = nil
+    }
+
+    func moveSelection(by offset: Int) {
+        guard !results.isEmpty else { return }
+        selectedIndex = max(0, min(selectedIndex + offset, results.count - 1))
+    }
+
+    func openSelected() {
+        guard results.indices.contains(selectedIndex),
+              openIfStillEligible(results[selectedIndex].url)
+        else { return }
+        onOpen?()
+    }
+
+    func actions(for item: FileSearchItem) -> [ActionItem] {
+        let url = item.url
+        return [
+            ActionItem(title: "Open", icon: "arrow.up.forward.app", shortcut: "↵") { [weak self] in
+                _ = self?.openIfStillEligible(url)
+            },
+            ActionItem(title: "Show in Finder", icon: "folder", shortcut: nil) {
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            },
+            ActionItem(title: "Quick Look", icon: "eye", shortcut: nil) { [weak self] in
+                guard self?.eligibleItem(at: url) != nil else { return }
+                QuickLookPreviewController.shared.preview(url)
+            },
+            ActionItem(title: "Copy Path", icon: "doc.on.doc", shortcut: nil) {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(url.path, forType: .string)
+            },
+            ActionItem(title: "Open With…", icon: "square.and.arrow.up", shortcut: nil) { [weak self] in
+                guard self?.eligibleItem(at: url) != nil else { return }
+                Self.chooseApplicationAndOpen(url)
+            }
+        ]
+    }
+
+    private func scheduleSearch() {
+        // Stop the previous Spotlight query immediately. Otherwise it can finish
+        // during the debounce interval and briefly publish stale results.
+        cancelQuery()
+        let trimmed = queryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            results = []
+            selectedIndex = 0
+            return
+        }
+        guard configurationLoaded, allLocations || !searchPaths.isEmpty else {
+            results = []
+            selectedIndex = 0
+            if errorMessage == nil {
+                errorMessage = "Choose at least one File Search folder in Settings."
+            }
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in
+            self?.startSearch(trimmed)
+        }
+        debounceWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)
+    }
+
+    private func startSearch(_ text: String) {
+        guard text == queryText.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+        cancelQuery()
+        let query = NSMetadataQuery()
+        query.predicate = NSPredicate(format: "%K CONTAINS[cd] %@", NSMetadataItemFSNameKey, text)
+        query.sortDescriptors = [
+            NSSortDescriptor(
+                key: NSMetadataItemFSNameKey,
+                ascending: true,
+                selector: #selector(NSString.localizedStandardCompare(_:))
+            )
+        ]
+        if allLocations {
+            query.searchScopes = [NSMetadataQueryLocalComputerScope]
+        } else {
+            query.searchScopes = searchPaths.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(queryDidFinish(_:)),
+            name: .NSMetadataQueryDidFinishGathering,
+            object: query
+        )
+        metadataQuery = query
+        query.operationQueue = .main
+        isSearching = true
+        errorMessage = nil
+        guard query.start() else {
+            isSearching = false
+            errorMessage = "Spotlight search could not start."
+            stop(query)
+            return
+        }
+    }
+
+    @objc private func queryDidFinish(_ notification: Notification) {
+        guard let query = notification.object as? NSMetadataQuery,
+              query === metadataQuery else { return }
+        query.disableUpdates()
+        let items = query.results.compactMap { result -> FileSearchItem? in
+            guard let metadata = result as? NSMetadataItem,
+                  let path = metadata.value(forAttribute: NSMetadataItemPathKey) as? String
+            else { return nil }
+            return eligibleItem(at: URL(fileURLWithPath: path))
+        }
+        query.enableUpdates()
+        results = Array(items
+            .sorted {
+                if $0.isDirectory != $1.isDirectory { return $0.isDirectory }
+                return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+            }
+            .prefix(100))
+        selectedIndex = 0
+        isSearching = false
+        stop(query)
+    }
+
+    func eligibleItem(at url: URL) -> FileSearchItem? {
+        let standardizedURL = url.standardizedFileURL
+        let resolvedURL = standardizedURL.resolvingSymlinksInPath()
+        guard isWithinConfiguredScope(resolvedURL) else { return nil }
+        if resolvedURL.pathComponents.contains(where: { $0.lowercased().hasSuffix(".app") }) {
+            return nil
+        }
+        let keys: Set<URLResourceKey> = [.isDirectoryKey, .isRegularFileKey, .isHiddenKey, .isExecutableKey]
+        guard let values = try? resolvedURL.resourceValues(forKeys: keys) else { return nil }
+        let isDirectory = values.isDirectory == true
+        guard isDirectory || values.isRegularFile == true else { return nil }
+        let hasHiddenComponent = resolvedURL.pathComponents.contains { component in
+            component.hasPrefix(".") && component != "." && component != ".."
+        }
+        if !includeHidden && (values.isHidden == true || hasHiddenComponent) { return nil }
+        let isExecutable = values.isExecutable == true
+            || FileManager.default.isExecutableFile(atPath: resolvedURL.path)
+        if !isDirectory && isExecutable { return nil }
+        return FileSearchItem(url: standardizedURL, isDirectory: isDirectory)
+    }
+
+    private func isWithinConfiguredScope(_ url: URL) -> Bool {
+        guard !allLocations else { return true }
+        let candidate = url.path
+        return searchPaths.contains { scopePath in
+            candidate == scopePath || candidate.hasPrefix(scopePath.hasSuffix("/") ? scopePath : scopePath + "/")
+        }
+    }
+
+    @discardableResult
+    private func openIfStillEligible(_ url: URL) -> Bool {
+        guard let item = eligibleItem(at: url) else {
+            results.removeAll { $0.url == url }
+            selectedIndex = min(selectedIndex, max(0, results.count - 1))
+            errorMessage = "The item is no longer eligible for File Search."
+            return false
+        }
+        guard NSWorkspace.shared.open(item.url) else {
+            errorMessage = "The item could not be opened."
+            return false
+        }
+        return true
+    }
+
+    private func cancelQuery() {
+        debounceWork?.cancel()
+        debounceWork = nil
+        if let query = metadataQuery { stop(query) }
+        metadataQuery = nil
+        isSearching = false
+    }
+
+    private func stop(_ query: NSMetadataQuery) {
+        NotificationCenter.default.removeObserver(self, name: .NSMetadataQueryDidFinishGathering, object: query)
+        query.stop()
+        if metadataQuery === query { metadataQuery = nil }
+    }
+
+    private static func chooseApplicationAndOpen(_ url: URL) {
+        let panel = NSOpenPanel()
+        panel.title = "Choose an application"
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.application]
+        guard panel.runModal() == .OK, let applicationURL = panel.url else { return }
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: applicationURL,
+            configuration: configuration
+        )
+    }
+}
+
+@MainActor
+private final class QuickLookPreviewController: NSObject, @preconcurrency QLPreviewPanelDataSource {
+    static let shared = QuickLookPreviewController()
+    private var url: URL?
+
+    func preview(_ url: URL) {
+        self.url = url
+        guard let panel = QLPreviewPanel.shared() else { return }
+        panel.dataSource = self
+        panel.reloadData()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int { url == nil ? 0 : 1 }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> any QLPreviewItem {
+        (url ?? URL(fileURLWithPath: "/")) as NSURL
+    }
+}

--- a/AintoApp/Sources/Services/SystemActionService.swift
+++ b/AintoApp/Sources/Services/SystemActionService.swift
@@ -1,0 +1,117 @@
+import AppKit
+import Foundation
+
+enum SystemAction: String, CaseIterable, Identifiable {
+    case sleep
+    case lockScreen = "lock-screen"
+    case logOut = "log-out"
+    case restart
+    case shutDown = "shut-down"
+    case emptyTrash = "empty-trash"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .sleep: "Sleep"
+        case .lockScreen: "Lock Screen"
+        case .logOut: "Log Out"
+        case .restart: "Restart"
+        case .shutDown: "Shut Down"
+        case .emptyTrash: "Empty Trash"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .sleep: "moon.zzz"
+        case .lockScreen: "lock.fill"
+        case .logOut: "rectangle.portrait.and.arrow.right"
+        case .restart: "restart"
+        case .shutDown: "power"
+        case .emptyTrash: "trash"
+        }
+    }
+
+    var requiresConfirmation: Bool {
+        switch self {
+        case .logOut, .restart, .shutDown: true
+        default: false
+        }
+    }
+}
+
+enum SystemActionError: LocalizedError {
+    case unavailable(String)
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let message), .failed(let message): message
+        }
+    }
+}
+
+enum SystemActionService {
+    /// Executes only fixed operations selected from `SystemAction`.
+    static func execute(_ action: SystemAction) throws {
+        switch action {
+        case .sleep:
+            try run("/usr/bin/pmset", arguments: ["sleepnow"])
+        case .lockScreen:
+            try lockScreen()
+        case .emptyTrash:
+            try runAppleScript("tell application \"Finder\" to empty trash")
+        case .logOut:
+            try runAppleScript("tell application \"System Events\" to log out")
+        case .restart:
+            try runAppleScript("tell application \"System Events\" to restart")
+        case .shutDown:
+            try runAppleScript("tell application \"System Events\" to shut down")
+        }
+    }
+
+    private static func lockScreen() throws {
+        guard AXIsProcessTrusted() else {
+            throw SystemActionError.unavailable("Enable Accessibility access for Ainto to lock the screen.")
+        }
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x0C, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x0C, keyDown: false)
+        else {
+            throw SystemActionError.unavailable("The macOS lock screen shortcut is unavailable.")
+        }
+        let flags: CGEventFlags = [.maskCommand, .maskControl]
+        keyDown.flags = flags
+        keyUp.flags = flags
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    private static func runAppleScript(_ fixedScript: String) throws {
+        try run("/usr/bin/osascript", arguments: ["-e", fixedScript])
+    }
+
+    private static func run(_ executable: String, arguments: [String]) throws {
+        guard FileManager.default.isExecutableFile(atPath: executable) else {
+            throw SystemActionError.unavailable("The macOS system helper is unavailable.")
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw SystemActionError.failed(error.localizedDescription)
+        }
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw SystemActionError.failed(message.flatMap { $0.isEmpty ? nil : $0 } ?? "The system action failed.")
+        }
+    }
+}

--- a/AintoApp/Sources/Views/AliasSettingsView.swift
+++ b/AintoApp/Sources/Views/AliasSettingsView.swift
@@ -1,0 +1,222 @@
+import AppKit
+import SwiftUI
+import AintoCore
+
+struct AliasSettingsView: View {
+    @State private var aliases: [LauncherAlias] = []
+    @State private var targets: [AliasTargetOption] = []
+    @State private var newAlias = ""
+    @State private var selectedTarget: LauncherTargetRef?
+    @State private var targetFilter = ""
+    @State private var validationError: String?
+    @State private var savedMessage: String?
+
+    private var filteredTargets: [AliasTargetOption] {
+        let filter = targetFilter.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !filter.isEmpty else { return targets }
+        return targets.filter {
+            $0.title.localizedCaseInsensitiveContains(filter)
+                || $0.detail.localizedCaseInsensitiveContains(filter)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            SectionHeader(title: "Aliases", icon: "arrow.triangle.branch")
+
+            Text(
+                "Aliases are exact, case-insensitive shortcuts. "
+                    + "They promote the mapped result without hiding normal search matches."
+            )
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            SettingsCard {
+                VStack(spacing: 12) {
+                    TextField("New alias, for example tc", text: $newAlias)
+                        .textFieldStyle(.roundedBorder)
+                    TextField("Filter targets", text: $targetFilter)
+                        .textFieldStyle(.roundedBorder)
+                    Picker("Target", selection: $selectedTarget) {
+                        Text("Choose a target").tag(Optional<LauncherTargetRef>.none)
+                        ForEach(filteredTargets) { target in
+                            Text("\(target.title) — \(target.detail)")
+                                .tag(Optional(target.ref))
+                        }
+                    }
+                    HStack {
+                        Spacer()
+                        Button("Add Alias") { addAlias() }
+                            .disabled(AliasStore.normalize(newAlias).isEmpty || selectedTarget == nil)
+                    }
+                }
+            }
+
+            if aliases.isEmpty {
+                Text("No aliases configured.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.tertiary)
+            } else {
+                SettingsCard {
+                    VStack(spacing: 12) {
+                        ForEach(Array(aliases.indices), id: \.self) { index in
+                            HStack(spacing: 10) {
+                                TextField("Alias", text: $aliases[index].alias)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 110)
+                                Picker("", selection: targetBinding(index)) {
+                                    ForEach(targetsIncludingUnavailable(for: aliases[index])) { target in
+                                        Text("\(target.title) — \(target.detail)").tag(target.ref)
+                                    }
+                                }
+                                .labelsHidden()
+                                Spacer()
+                                Button {
+                                    aliases.remove(at: index)
+                                    persist()
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
+                                .buttonStyle(.plain)
+                                .foregroundStyle(.red)
+                            }
+                            if index < aliases.count - 1 { Divider().opacity(0.25) }
+                        }
+                        HStack {
+                            Spacer()
+                            Button("Save Changes") { persist() }
+                        }
+                    }
+                }
+            }
+
+            if let validationError {
+                Text(validationError).font(.system(size: 12)).foregroundStyle(.red)
+            } else if let savedMessage {
+                Text(savedMessage).font(.system(size: 12)).foregroundStyle(.green)
+            }
+        }
+        .onAppear {
+            aliases = AliasStore.load()
+            targets = Self.loadTargets()
+            selectedTarget = targets.first?.ref
+        }
+    }
+
+    private func targetBinding(_ index: Int) -> Binding<LauncherTargetRef> {
+        Binding(
+            get: { aliases[index].target },
+            set: {
+                aliases[index].targetType = $0.kind
+                aliases[index].targetID = $0.id
+            }
+        )
+    }
+
+    private func targetsIncludingUnavailable(for entry: LauncherAlias) -> [AliasTargetOption] {
+        guard !targets.contains(where: { $0.ref == entry.target }) else { return targets }
+        return targets + [AliasTargetOption(ref: entry.target, title: "Unavailable target", detail: entry.targetID)]
+    }
+
+    private func addAlias() {
+        guard let selectedTarget else { return }
+        let entry = LauncherAlias(
+            alias: newAlias.trimmingCharacters(in: .whitespacesAndNewlines),
+            targetType: selectedTarget.kind,
+            targetID: selectedTarget.id
+        )
+        let candidate = aliases + [entry]
+        if let error = AliasStore.validate(candidate) {
+            validationError = error
+            savedMessage = nil
+            return
+        }
+        aliases = candidate
+        newAlias = ""
+        persist()
+    }
+
+    private func persist() {
+        if let error = AliasStore.validate(aliases) {
+            validationError = error
+            savedMessage = nil
+            return
+        }
+        guard AliasStore.save(aliases) else {
+            validationError = "Aliases could not be saved."
+            savedMessage = nil
+            return
+        }
+        validationError = nil
+        savedMessage = "Aliases saved."
+    }
+
+    private static func loadTargets() -> [AliasTargetOption] {
+        var options: [AliasTargetOption] = [
+            AliasTargetOption(
+                ref: LauncherTargetRef(kind: .launcherCommand, id: "file-search"),
+                title: "File Search",
+                detail: "Launcher Command"
+            ),
+            AliasTargetOption(
+                ref: LauncherTargetRef(kind: .launcherCommand, id: "clipboard-history"),
+                title: "Clipboard History",
+                detail: "Launcher Command"
+            )
+        ]
+
+        options += SystemAction.allCases.map {
+            AliasTargetOption(
+                ref: LauncherTargetRef(kind: .systemAction, id: $0.id),
+                title: $0.title,
+                detail: "System Action"
+            )
+        }
+        options += AICommand.loadAll().map {
+            AliasTargetOption(
+                ref: LauncherTargetRef(kind: .aiCommand, id: $0.id),
+                title: $0.name,
+                detail: "AI Command"
+            )
+        }
+        options += loadSnippetTargets()
+        options += loadAppTargets()
+        return options.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+    }
+
+    private static func loadSnippetTargets() -> [AliasTargetOption] {
+        guard let cString = rc_snippets_load() else { return [] }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return entries.compactMap { entry in
+            guard let id = entry["id"] as? String else { return nil }
+            return AliasTargetOption(
+                ref: LauncherTargetRef(kind: .snippet, id: id),
+                title: entry["name"] as? String ?? "Untitled Snippet",
+                detail: "Snippet"
+            )
+        }
+    }
+
+    private static func loadAppTargets() -> [AliasTargetOption] {
+        guard let cString = rc_get_all_apps() else { return [] }
+        defer { rc_free_string(cString) }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return entries.compactMap { entry in
+            guard let path = entry["path"] as? String else { return nil }
+            let bundleID = entry["bundle_id"] as? String
+            return AliasTargetOption(
+                ref: SearchViewModel.appTargetRef(bundleID: bundleID, path: path),
+                title: entry["display_name"] as? String
+                    ?? URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent,
+                detail: "Application"
+            )
+        }
+    }
+}

--- a/AintoApp/Sources/Views/FileSearchSettingsView.swift
+++ b/AintoApp/Sources/Views/FileSearchSettingsView.swift
@@ -1,0 +1,121 @@
+import AppKit
+import SwiftUI
+
+struct FileSearchSettingsView: View {
+    @Binding var paths: [String]
+    @Binding var allLocations: Bool
+    @Binding var includeHidden: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SectionHeader(title: "File Search", icon: "doc.text.magnifyingglass")
+
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    SettingsRow(label: "Search entire Mac") {
+                        Toggle("", isOn: $allLocations).labelsHidden().toggleStyle(.switch)
+                    }
+                    Text(
+                        "Full Disk Access grants permission, while this toggle expands "
+                            + "the Spotlight scope beyond the folders below."
+                    )
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                    Divider().opacity(0.3)
+                    SettingsRow(label: "Include hidden files") {
+                        Toggle("", isOn: $includeHidden).labelsHidden().toggleStyle(.switch)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Search folders")
+                        .font(.system(size: 14, weight: .medium))
+                    Spacer()
+                    Button("Add Folder…") { addFolder() }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.accentColor)
+                }
+                SettingsCard {
+                    VStack(spacing: 10) {
+                        ForEach(paths, id: \.self) { path in
+                            HStack(spacing: 10) {
+                                Image(systemName: "folder")
+                                    .foregroundStyle(.secondary)
+                                Text(path)
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .lineLimit(1)
+                                Spacer()
+                                Button {
+                                    paths.removeAll { $0 == path }
+                                } label: {
+                                    Image(systemName: "minus.circle")
+                                        .foregroundStyle(.secondary)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove folder")
+                            }
+                        }
+                    }
+                }
+                if paths.isEmpty && !allLocations {
+                    Text("Add at least one folder or enable Search entire Mac.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                } else if allLocations {
+                    Text("These folders will be used when Search entire Mac is turned off.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            SettingsCard {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Full Disk Access")
+                            .font(.system(size: 13))
+                        Text(
+                            "Allows Spotlight to return more protected indexed locations. "
+                                + "It does not scan unindexed files."
+                        )
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Button("Open Settings") { openFullDiskAccessSettings() }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+        }
+    }
+
+    private func addFolder() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a File Search folder"
+        // Start at the filesystem root so system folders such as /Library are
+        // visible without requiring the user to know Finder's Go to Folder shortcut.
+        panel.directoryURL = URL(fileURLWithPath: "/", isDirectory: true)
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            let path = url.standardizedFileURL.resolvingSymlinksInPath().path
+            if !paths.contains(path) { paths.append(path) }
+        }
+    }
+
+    private func openFullDiskAccessSettings() {
+        // Permission alone does not change NSMetadataQuery's scope. Enable the
+        // whole-Mac scope so returning from System Settings behaves as expected.
+        allLocations = true
+        let primary = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
+        if !NSWorkspace.shared.open(primary),
+           let fallback = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension") {
+            NSWorkspace.shared.open(fallback)
+        }
+    }
+}

--- a/AintoApp/Sources/Views/FileSearchView.swift
+++ b/AintoApp/Sources/Views/FileSearchView.swift
@@ -1,0 +1,196 @@
+import AppKit
+import SwiftUI
+
+struct FileSearchView: View {
+    @ObservedObject var viewModel: SearchViewModel
+    @ObservedObject var service: FileSearchService
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Button(action: { viewModel.goBack() }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+
+                Image(systemName: "doc.text.magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 16))
+
+                TextField("Search files and folders…", text: $service.queryText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 16))
+                    .focused($focused)
+                    .onAppear {
+                        service.reloadConfiguration()
+                        focused = true
+                    }
+                if service.isSearching {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+
+            Divider().opacity(0.5)
+
+            if let error = service.errorMessage {
+                ContentUnavailableView("Search unavailable", systemImage: "exclamationmark.triangle", description: Text(error))
+                    .frame(height: 330)
+            } else if service.queryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ContentUnavailableView(
+                    "File Search",
+                    systemImage: "doc.text.magnifyingglass",
+                    description: Text("Type a filename to search the folders configured in Settings.")
+                )
+                .frame(height: 330)
+            } else if service.results.isEmpty && !service.isSearching {
+                ContentUnavailableView("No files found", systemImage: "doc.text.magnifyingglass")
+                    .frame(height: 330)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 2) {
+                            ForEach(Array(service.results.enumerated()), id: \.element.id) { index, item in
+                                FileSearchResultRow(item: item, selected: index == service.selectedIndex)
+                                    .id(item.id)
+                                    .onTapGesture(count: 2) {
+                                        service.selectedIndex = index
+                                        service.openSelected()
+                                    }
+                                    .onTapGesture {
+                                        service.selectedIndex = index
+                                    }
+                                    .contextMenu {
+                                        ForEach(service.actions(for: item)) { action in
+                                            Button(action: action.action) {
+                                                Label(action.title, systemImage: action.icon)
+                                            }
+                                        }
+                                    }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .frame(height: 330)
+                    .onChange(of: service.selectedIndex) { _, index in
+                        guard service.results.indices.contains(index) else { return }
+                        proxy.scrollTo(service.results[index].id)
+                    }
+                }
+            }
+
+            Divider().opacity(0.3)
+            HStack {
+                Text("\(service.results.count) results")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                HStack(spacing: 12) {
+                    KeyHint(keys: ["⌘", "K"], label: "actions")
+                    KeyHint(keys: ["↑", "↓"], label: "navigate")
+                    KeyHint(keys: ["↵"], label: "open")
+                    KeyHint(keys: ["esc"], label: "back")
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 680)
+    }
+}
+
+private struct FileSearchResultRow: View {
+    let item: FileSearchItem
+    let selected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: item.icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.system(size: 14, weight: selected ? .semibold : .regular))
+                    .foregroundStyle(selected ? .white : .primary)
+                    .lineLimit(1)
+                Text(item.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(selected ? .white.opacity(0.75) : .secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            if item.isDirectory {
+                Text("Folder")
+                    .font(.system(size: 10))
+                    .foregroundStyle(selected ? Color.white.opacity(0.7) : Color.secondary.opacity(0.7))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background {
+            if selected {
+                RoundedRectangle(cornerRadius: 10).fill(Color.accentColor.opacity(0.85))
+            }
+        }
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
+    }
+}
+
+struct SystemActionConfirmationView: View {
+    @ObservedObject var viewModel: SearchViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: viewModel.pendingSystemAction?.icon ?? "exclamationmark.triangle")
+                .font(.system(size: 42))
+                .foregroundStyle(.orange)
+            Text(viewModel.isExecutingSystemAction
+                 ? "Running \(viewModel.pendingSystemAction?.title ?? "System Action")…"
+                 : "Confirm \(viewModel.pendingSystemAction?.title ?? "System Action")")
+                .font(.system(size: 20, weight: .semibold))
+            Text(viewModel.isExecutingSystemAction
+                 ? "Ainto is asking macOS to perform this action."
+                 : "This action affects your current macOS session.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            if let error = viewModel.systemActionError {
+                Text(error)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            }
+            if viewModel.isExecutingSystemAction {
+                ProgressView().controlSize(.small)
+            } else {
+                HStack(spacing: 12) {
+                    Button("Cancel") { viewModel.cancelSystemAction() }
+                        .keyboardShortcut(.cancelAction)
+                    Button(viewModel.systemActionError == nil
+                           ? (viewModel.pendingSystemAction?.title ?? "Continue")
+                           : "Try Again", role: .destructive) {
+                        viewModel.confirmSystemAction()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+            Spacer()
+            Divider().opacity(0.3)
+            HStack {
+                Spacer()
+                if !viewModel.isExecutingSystemAction {
+                    KeyHint(keys: ["↵"], label: viewModel.systemActionError == nil ? "confirm" : "retry")
+                    KeyHint(keys: ["esc"], label: "cancel")
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 680, height: 300)
+    }
+}

--- a/AintoApp/Sources/Views/MainView.swift
+++ b/AintoApp/Sources/Views/MainView.swift
@@ -17,6 +17,10 @@ struct MainView: View {
                 SnippetView(viewModel: viewModel)
             case .aiCommands:
                 AICommandView(viewModel: viewModel)
+            case .fileSearch:
+                FileSearchView(viewModel: viewModel, service: viewModel.fileSearch)
+            case .systemConfirmation:
+                SystemActionConfirmationView(viewModel: viewModel)
             case .claude:
                 ClaudeView(viewModel: viewModel)
             }

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -83,8 +83,12 @@ final class SearchPanel: NSPanel {
     private var hasUserPosition = false
 
     func showPanel() {
-        // Remember the currently focused app before showing
-        previousApp = NSWorkspace.shared.frontmostApplication
+        // Alias editing activates Ainto. Preserve the last external app so
+        // actions still return to the user's actual target application.
+        if let frontmost = NSWorkspace.shared.frontmostApplication,
+           frontmost.bundleIdentifier != Bundle.main.bundleIdentifier {
+            previousApp = frontmost
+        }
 
         // Pick up any Settings change to the AI master switch.
         viewModel.loadAISettings()
@@ -145,34 +149,56 @@ final class SearchPanel: NSPanel {
     }
 
     /// Hide panel, activate previous app, simulate Cmd+C to grab selection, then call back.
-    func grabSelectionFromPreviousApp(completion: @escaping (String) -> Void) {
-        let pasteboard = NSPasteboard.general
-        let previousContent = pasteboard.string(forType: .string)
+    func grabSelectionFromPreviousApp(completion: @MainActor @escaping (SelectionCaptureResult) -> Void) {
+        guard AXIsProcessTrusted() else {
+            let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+            AXIsProcessTrustedWithOptions(options)
+            let message = "Ainto needs Accessibility permission to read selected text. "
+                + "Enable Ainto in System Settings → Privacy & Security → Accessibility, then try again."
+            completion(.failure(message))
+            return
+        }
+        guard let previousApp else {
+            completion(.failure("Ainto could not identify the app containing the selected text."))
+            return
+        }
 
-        // Hide panel and activate previous app
-        hidePanel()
-        previousApp?.activate()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let pasteboard = NSPasteboard.general
+            let previousContent = pasteboard.string(forType: .string)
 
-        // Wait for app activation, then simulate Cmd+C
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            hidePanel()
+            previousApp.activate()
+            try? await Task.sleep(nanoseconds: 150_000_000)
+
             pasteboard.clearContents()
-            self.simulateCopy()
+            let clearedChangeCount = pasteboard.changeCount
+            simulateCopy()
 
-            // Wait for clipboard to update
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                let selection = pasteboard.string(forType: .string) ?? ""
-
-                // Restore previous clipboard content
-                pasteboard.clearContents()
-                if let prev = previousContent {
-                    pasteboard.setString(prev, forType: .string)
-                    pasteboard.setData(Data(), forType: NSPasteboard.PasteboardType("org.nspasteboard.TransientType"))
+            // Some applications update the pasteboard asynchronously. Poll for
+            // at most one second instead of assuming 150 ms is always enough.
+            var selection = ""
+            for _ in 0..<20 {
+                if pasteboard.changeCount != clearedChangeCount,
+                   let copiedText = pasteboard.string(forType: .string) {
+                    selection = copiedText
+                    break
                 }
-
-                // Re-show panel and call back
-                self.makeKeyAndOrderFront(nil)
-                completion(selection)
+                try? await Task.sleep(nanoseconds: 50_000_000)
             }
+
+            pasteboard.clearContents()
+            if let previousContent {
+                pasteboard.setString(previousContent, forType: .string)
+                pasteboard.setData(
+                    Data(),
+                    forType: NSPasteboard.PasteboardType("org.nspasteboard.TransientType")
+                )
+            }
+
+            makeKeyAndOrderFront(nil)
+            completion(.success(selection))
         }
     }
 

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_body_length function_body_length cyclomatic_complexity identifier_name file_length
 import AppKit
 import SwiftUI
 
@@ -72,6 +73,8 @@ final class SearchPanel: NSPanel {
         viewModel.onGrabSelection = { [weak self] completion in
             self?.grabSelectionFromPreviousApp(completion: completion)
         }
+        viewModel.fileSearch.onOpen = { [weak self] in self?.hidePanel() }
+        viewModel.onSystemActionCompleted = { [weak self] in self?.hidePanel() }
 
         viewModel.loadAISettings()
     }
@@ -109,6 +112,7 @@ final class SearchPanel: NSPanel {
 
     func hidePanel() {
         hideActionPanel()
+        viewModel.prepareForPanelHide()
         orderOut(nil)
     }
 
@@ -190,8 +194,7 @@ final class SearchPanel: NSPanel {
         guard !actions.isEmpty else { return }
         actionSelectedIndex = 0
 
-        let title = viewModel.results.indices.contains(viewModel.selectedIndex)
-            ? viewModel.results[viewModel.selectedIndex].title : ""
+        let title = viewModel.currentActionTitle
 
         let panelView = ActionPanelView(
             title: title,
@@ -235,8 +238,7 @@ final class SearchPanel: NSPanel {
     func updateActionPanelSelection() {
         guard let window = actionWindow else { return }
         let actions = viewModel.currentActions
-        let title = viewModel.results.indices.contains(viewModel.selectedIndex)
-            ? viewModel.results[viewModel.selectedIndex].title : ""
+        let title = viewModel.currentActionTitle
 
         let panelView = ActionPanelView(
             title: title,

--- a/AintoApp/Sources/Views/SettingsView.swift
+++ b/AintoApp/Sources/Views/SettingsView.swift
@@ -32,6 +32,7 @@ struct SettingsView: View {
         case ai = "AI"
         case snippets = "Snippets"
         case fileSearch = "File Search"
+        case aliases = "Aliases"
         case data = "Data"
         case about = "About"
 
@@ -42,6 +43,7 @@ struct SettingsView: View {
             case .ai: return "sparkle"
             case .snippets: return "text.quote"
             case .fileSearch: return "doc.text.magnifyingglass"
+            case .aliases: return "arrow.triangle.branch"
             case .data: return "folder"
             case .about: return "info.circle"
             }
@@ -76,6 +78,7 @@ struct SettingsView: View {
                     case .ai: aiSection
                     case .snippets: snippetsSection
                     case .fileSearch: fileSearchSection
+                    case .aliases: AliasSettingsView()
                     case .data: dataSection
                     case .about: aboutSection
                     }

--- a/AintoApp/Sources/Views/SettingsView.swift
+++ b/AintoApp/Sources/Views/SettingsView.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length
+// swiftlint:disable file_length type_body_length function_body_length identifier_name line_length
 import SwiftUI
 import AppKit
 import AintoCore
@@ -14,6 +16,9 @@ struct SettingsView: View {
     @State private var claudeBinary: String = "claude"
     @State private var aiEnabled: Bool = true
     @State private var snippetsEnabled: Bool = true
+    @State private var fileSearchPaths: [String] = [NSHomeDirectory()]
+    @State private var fileSearchAllLocations = false
+    @State private var fileSearchIncludeHidden = false
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var selectedHotkey: String = "⌘ ⇧ Space"
     @State private var hasLoaded = false
@@ -26,6 +31,7 @@ struct SettingsView: View {
         case clipboard = "Clipboard"
         case ai = "AI"
         case snippets = "Snippets"
+        case fileSearch = "File Search"
         case data = "Data"
         case about = "About"
 
@@ -35,6 +41,7 @@ struct SettingsView: View {
             case .clipboard: return "doc.on.clipboard"
             case .ai: return "sparkle"
             case .snippets: return "text.quote"
+            case .fileSearch: return "doc.text.magnifyingglass"
             case .data: return "folder"
             case .about: return "info.circle"
             }
@@ -68,6 +75,7 @@ struct SettingsView: View {
                     case .clipboard: clipboardSection
                     case .ai: aiSection
                     case .snippets: snippetsSection
+                    case .fileSearch: fileSearchSection
                     case .data: dataSection
                     case .about: aboutSection
                     }
@@ -87,6 +95,9 @@ struct SettingsView: View {
         .onChange(of: claudeBinary) { _, _ in saveConfig() }
         .onChange(of: aiEnabled) { _, _ in saveConfig() }
         .onChange(of: snippetsEnabled) { _, _ in saveConfig() }
+        .onChange(of: fileSearchPaths) { _, _ in saveConfig() }
+        .onChange(of: fileSearchAllLocations) { _, _ in saveConfig() }
+        .onChange(of: fileSearchIncludeHidden) { _, _ in saveConfig() }
         .alert("Reset Rankings", isPresented: $showResetConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Reset", role: .destructive) {
@@ -331,6 +342,16 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - File Search
+
+    private var fileSearchSection: some View {
+        FileSearchSettingsView(
+            paths: $fileSearchPaths,
+            allLocations: $fileSearchAllLocations,
+            includeHidden: $fileSearchIncludeHidden
+        )
+    }
+
     // MARK: - Data
 
     private var dataSection: some View {
@@ -496,6 +517,9 @@ struct SettingsView: View {
         claudeBinary = config["claude_binary"] as? String ?? "claude"
         aiEnabled = config["ai_enabled"] as? Bool ?? true
         snippetsEnabled = config["snippets_enabled"] as? Bool ?? true
+        fileSearchPaths = config["file_search_paths"] as? [String] ?? [NSHomeDirectory()]
+        fileSearchAllLocations = config["file_search_all_locations"] as? Bool ?? false
+        fileSearchIncludeHidden = config["file_search_include_hidden"] as? Bool ?? false
         hasLoaded = true
     }
 
@@ -507,6 +531,9 @@ struct SettingsView: View {
             "claude_binary": claudeBinary,
             "ai_enabled": aiEnabled,
             "snippets_enabled": snippetsEnabled,
+            "file_search_paths": fileSearchPaths,
+            "file_search_all_locations": fileSearchAllLocations,
+            "file_search_include_hidden": fileSearchIncludeHidden,
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: config),
               let jsonStr = String(data: data, encoding: .utf8) else { return }

--- a/AintoApp/Tests/AliasServiceTests.swift
+++ b/AintoApp/Tests/AliasServiceTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+#if SWIFT_PACKAGE
+@testable import AintoApp
+#else
+@testable import Ainto
+#endif
+
+final class AliasServiceTests: XCTestCase {
+    func testNormalizationIsUnicodeCaseInsensitive() {
+        XCTAssertEqual(AliasStore.normalize("  Straße  "), AliasStore.normalize("STRASSE"))
+    }
+
+    func testNormalizationCanonicalizesEquivalentUnicode() {
+        XCTAssertEqual(AliasStore.normalize("café"), AliasStore.normalize("cafe\u{301}"))
+    }
+
+    func testValidationRejectsUnicodeEquivalentDuplicates() {
+        let aliases = [
+            LauncherAlias(alias: "Straße", targetType: .systemAction, targetID: "sleep"),
+            LauncherAlias(alias: "STRASSE", targetType: .systemAction, targetID: "restart"),
+        ]
+        XCTAssertNotNil(AliasStore.validate(aliases))
+    }
+
+    func testAppTargetsDistinguishDuplicateBundleIDs() {
+        let first = SearchViewModel.appTargetRef(
+            bundleID: "com.example.app",
+            path: "/Applications/Example.app"
+        )
+        let second = SearchViewModel.appTargetRef(
+            bundleID: "com.example.app",
+            path: "/Users/example/Example.app"
+        )
+        XCTAssertNotEqual(first, second)
+    }
+}

--- a/AintoApp/Tests/SystemActionServiceTests.swift
+++ b/AintoApp/Tests/SystemActionServiceTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+#if SWIFT_PACKAGE
+@testable import AintoApp
+#else
+@testable import Ainto
+#endif
+
+final class SystemActionServiceTests: XCTestCase {
+    func testConfirmationPolicy() {
+        XCTAssertFalse(SystemAction.sleep.requiresConfirmation)
+        XCTAssertFalse(SystemAction.lockScreen.requiresConfirmation)
+        XCTAssertFalse(SystemAction.emptyTrash.requiresConfirmation)
+        XCTAssertTrue(SystemAction.logOut.requiresConfirmation)
+        XCTAssertTrue(SystemAction.restart.requiresConfirmation)
+        XCTAssertTrue(SystemAction.shutDown.requiresConfirmation)
+    }
+}

--- a/AintoApp/project.yml
+++ b/AintoApp/project.yml
@@ -63,6 +63,8 @@ targets:
       - sdk: Security.framework
       - sdk: SystemConfiguration.framework
       - sdk: ServiceManagement.framework
+      - sdk: QuickLookUI.framework
+      - sdk: UniformTypeIdentifiers.framework
     settings:
       base:
         GENERATE_INFOPLIST_FILE: NO

--- a/ainto-core/Cargo.lock
+++ b/ainto-core/Cargo.lock
@@ -25,6 +25,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "toml",
+ "unicode-casefold",
+ "unicode-normalization",
  "uuid",
  "xxhash-rust",
 ]
@@ -731,6 +733,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,10 +789,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/ainto-core/Cargo.toml
+++ b/ainto-core/Cargo.toml
@@ -28,8 +28,12 @@ dirs = "6"
 # Error handling
 thiserror = "2"
 
-# UUID for snippet IDs
+# UUID for snippet and AI command IDs
 uuid = { version = "1", features = ["v4"] }
+
+# Unicode-stable, case-insensitive alias matching
+unicode-normalization = "0.1"
+unicode-casefold = "0.2"
 
 # macOS frameworks (for app discovery)
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/ainto-core/src/ai_commands.rs
+++ b/ainto-core/src/ai_commands.rs
@@ -1,13 +1,16 @@
 //! Custom AI command management with TOML persistence.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
 use crate::Error;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AiCommand {
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub icon: Option<String>,
     pub prompt: String,
@@ -19,8 +22,8 @@ pub struct AiCommandFile {
     pub commands: Vec<AiCommand>,
 }
 
-/// Load AI commands from a TOML file.
-/// If file doesn't exist, creates it with default built-in commands.
+/// Load AI commands from a TOML file. Missing or duplicate IDs from older
+/// versions are migrated once and persisted so aliases survive command renames.
 pub fn load_commands(path: &Path) -> Result<Vec<AiCommand>, Error> {
     if !path.exists() {
         let defaults = default_commands();
@@ -29,67 +32,114 @@ pub fn load_commands(path: &Path) -> Result<Vec<AiCommand>, Error> {
     }
     let content = std::fs::read_to_string(path)?;
     let file: AiCommandFile = toml::from_str(&content)?;
-    Ok(file.commands)
+    let (commands, migrated) = ensure_stable_ids(file.commands);
+    if migrated {
+        save_commands(path, &commands)?;
+    }
+    Ok(commands)
+}
+
+fn ensure_stable_ids(mut commands: Vec<AiCommand>) -> (Vec<AiCommand>, bool) {
+    let mut seen = HashSet::new();
+    let mut migrated = false;
+    for command in &mut commands {
+        if command.id.trim().is_empty() || !seen.insert(command.id.clone()) {
+            command.id = uuid::Uuid::new_v4().to_string();
+            seen.insert(command.id.clone());
+            migrated = true;
+        }
+    }
+    (commands, migrated)
 }
 
 const SYS: &str = "IMPORTANT: Output ONLY the result text. No explanations, no preamble, no comments, no markdown formatting. Just the raw transformed text.";
 
 fn default_commands() -> Vec<AiCommand> {
-    vec![
-        AiCommand {
-            name: "Fix Spelling & Grammar".into(),
-            icon: Some("text.badge.checkmark".into()),
-            prompt: format!("{SYS}\n\nFix the spelling and grammar of the following text:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Improve Writing".into(),
-            icon: Some("text.badge.star".into()),
-            prompt: format!("{SYS}\n\nImprove the writing quality. Make it clearer and more professional:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Make Shorter".into(),
-            icon: Some("arrow.down.right.and.arrow.up.left".into()),
-            prompt: format!("{SYS}\n\nMake the following text more concise while keeping the meaning:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Make Longer".into(),
-            icon: Some("arrow.up.left.and.arrow.down.right".into()),
-            prompt: format!("{SYS}\n\nExpand and elaborate on the following text:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Change Tone to Professional".into(),
-            icon: Some("briefcase".into()),
-            prompt: format!("{SYS}\n\nRewrite the following text in a professional tone:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Change Tone to Casual".into(),
-            icon: Some("face.smiling".into()),
-            prompt: format!("{SYS}\n\nRewrite the following text in a casual, friendly tone:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Translate to English".into(),
-            icon: Some("globe".into()),
-            prompt: format!("{SYS}\n\nTranslate the following text to English:\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Translate to Traditional Chinese".into(),
-            icon: Some("globe.asia.australia".into()),
-            prompt: format!("{SYS}\n\nTranslate the following text to Traditional Chinese (繁體中文):\n\n{{selection}}"),
-        },
-        AiCommand {
-            name: "Explain This".into(),
-            icon: Some("questionmark.circle".into()),
-            prompt: "Explain the following text or code in simple terms:\n\n{selection}".into(),
-        },
-        AiCommand {
-            name: "Summarize".into(),
-            icon: Some("doc.plaintext".into()),
-            prompt: "Summarize the following text concisely:\n\n{selection}".into(),
-        },
-    ]
+    let commands = [
+        command(
+            "builtin-fix-spelling-grammar",
+            "Fix Spelling & Grammar",
+            "text.badge.checkmark",
+            format!(
+                "{SYS}\n\nFix the spelling and grammar of the following text:\n\n{{selection}}"
+            ),
+        ),
+        command(
+            "builtin-improve-writing",
+            "Improve Writing",
+            "text.badge.star",
+            format!(
+                "{SYS}\n\nImprove the writing quality. Make it clearer and more professional:\n\n{{selection}}"
+            ),
+        ),
+        command(
+            "builtin-make-shorter",
+            "Make Shorter",
+            "arrow.down.right.and.arrow.up.left",
+            format!(
+                "{SYS}\n\nMake the following text more concise while keeping the meaning:\n\n{{selection}}"
+            ),
+        ),
+        command(
+            "builtin-make-longer",
+            "Make Longer",
+            "arrow.up.left.and.arrow.down.right",
+            format!("{SYS}\n\nExpand and elaborate on the following text:\n\n{{selection}}"),
+        ),
+        command(
+            "builtin-tone-professional",
+            "Change Tone to Professional",
+            "briefcase",
+            format!("{SYS}\n\nRewrite the following text in a professional tone:\n\n{{selection}}"),
+        ),
+        command(
+            "builtin-tone-casual",
+            "Change Tone to Casual",
+            "face.smiling",
+            format!(
+                "{SYS}\n\nRewrite the following text in a casual, friendly tone:\n\n{{selection}}"
+            ),
+        ),
+        command(
+            "builtin-translate-english",
+            "Translate to English",
+            "globe",
+            format!("{SYS}\n\nTranslate the following text to English:\n\n{{selection}}"),
+        ),
+        command(
+            "builtin-translate-traditional-chinese",
+            "Translate to Traditional Chinese",
+            "globe.asia.australia",
+            format!(
+                "{SYS}\n\nTranslate the following text to Traditional Chinese (繁體中文):\n\n{{selection}}"
+            ),
+        ),
+        command(
+            "builtin-explain",
+            "Explain This",
+            "questionmark.circle",
+            "Explain the following text or code in simple terms:\n\n{selection}".into(),
+        ),
+        command(
+            "builtin-summarize",
+            "Summarize",
+            "doc.plaintext",
+            "Summarize the following text concisely:\n\n{selection}".into(),
+        ),
+    ];
+    commands.into_iter().collect()
 }
 
-/// Save AI commands to a TOML file.
+fn command(id: &str, name: &str, icon: &str, prompt: String) -> AiCommand {
+    AiCommand {
+        id: id.into(),
+        name: name.into(),
+        icon: Some(icon.into()),
+        prompt,
+    }
+}
+
+/// Save AI commands atomically.
 pub fn save_commands(path: &Path, commands: &[AiCommand]) -> Result<(), Error> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -98,6 +148,61 @@ pub fn save_commands(path: &Path, commands: &[AiCommand]) -> Result<(), Error> {
         commands: commands.to_vec(),
     };
     let content = toml::to_string_pretty(&file)?;
-    std::fs::write(path, content)?;
+    let temporary = path.with_extension("toml.tmp");
+    std::fs::write(&temporary, content)?;
+    std::fs::rename(temporary, path)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_missing_and_duplicate_ids() {
+        let commands = vec![
+            command("", "One", "sparkle", "one".into()),
+            command("same", "Two", "sparkle", "two".into()),
+            command("same", "Three", "sparkle", "three".into()),
+        ];
+        let (migrated, changed) = ensure_stable_ids(commands);
+        assert!(changed);
+        assert!(migrated.iter().all(|command| !command.id.is_empty()));
+        assert_eq!(
+            migrated
+                .iter()
+                .map(|command| &command.id)
+                .collect::<HashSet<_>>()
+                .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn preserves_existing_unique_ids() {
+        let commands = vec![command("stable", "Renamed", "sparkle", "prompt".into())];
+        let (migrated, changed) = ensure_stable_ids(commands);
+        assert!(!changed);
+        assert_eq!(migrated[0].id, "stable");
+    }
+
+    #[test]
+    fn loading_legacy_toml_persists_the_generated_id() {
+        let path = std::env::temp_dir().join(format!(
+            "ainto-ai-command-migration-{}.toml",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(
+            &path,
+            "[[commands]]\nname = \"Legacy\"\nicon = \"sparkle\"\nprompt = \"{selection}\"\n",
+        )
+        .unwrap();
+
+        let first = load_commands(&path).unwrap();
+        let second = load_commands(&path).unwrap();
+        assert!(!first[0].id.is_empty());
+        assert_eq!(first[0].id, second[0].id);
+
+        let _ = std::fs::remove_file(path);
+    }
 }

--- a/ainto-core/src/aliases.rs
+++ b/ainto-core/src/aliases.rs
@@ -1,0 +1,117 @@
+//! Global launcher aliases with TOML persistence.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use unicode_casefold::UnicodeCaseFold;
+use unicode_normalization::UnicodeNormalization;
+
+use crate::Error;
+
+#[derive(Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+pub struct AliasEntry {
+    pub alias: String,
+    pub target_type: String,
+    pub target_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[derive(Debug, Clone, Default)]
+struct AliasFile {
+    #[serde(default)]
+    aliases: Vec<AliasEntry>,
+}
+
+/// Normalize aliases for exact, Unicode-aware, case-insensitive matching.
+pub fn normalize_alias(value: &str) -> String {
+    value.trim().nfkc().case_fold().nfkc().collect()
+}
+
+pub fn validate_aliases(aliases: &[AliasEntry]) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    for entry in aliases {
+        let normalized = normalize_alias(&entry.alias);
+        if normalized.is_empty() {
+            return Err("Alias cannot be empty".into());
+        }
+        let valid_target_type = matches!(
+            entry.target_type.as_str(),
+            "app" | "ai_command" | "snippet" | "launcher_command" | "system_action"
+        );
+        if !valid_target_type || entry.target_id.trim().is_empty() {
+            return Err(format!("Alias '{}' has an invalid target", entry.alias));
+        }
+        if !seen.insert(normalized) {
+            return Err(format!("Alias '{}' is already in use", entry.alias.trim()));
+        }
+    }
+    Ok(())
+}
+
+pub fn load_aliases(path: &Path) -> Result<Vec<AliasEntry>, Error> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(path)?;
+    let file: AliasFile = toml::from_str(&content)?;
+    validate_aliases(&file.aliases).map_err(Error::InvalidAliases)?;
+    Ok(file.aliases)
+}
+
+pub fn save_aliases(path: &Path, aliases: &[AliasEntry]) -> Result<(), String> {
+    validate_aliases(aliases)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = toml::to_string_pretty(&AliasFile {
+        aliases: aliases.to_vec(),
+    })
+    .map_err(|e| e.to_string())?;
+    let temporary = path.with_extension("toml.tmp");
+    std::fs::write(&temporary, content).map_err(|e| e.to_string())?;
+    std::fs::rename(&temporary, path).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(alias: &str) -> AliasEntry {
+        AliasEntry {
+            alias: alias.into(),
+            target_type: "system_action".into(),
+            target_id: "sleep".into(),
+        }
+    }
+
+    #[test]
+    fn normalization_is_trimmed_and_case_insensitive() {
+        assert_eq!(normalize_alias("  TC  "), "tc");
+    }
+
+    #[test]
+    fn duplicate_aliases_are_rejected_case_insensitively() {
+        let error = validate_aliases(&[entry("tc"), entry(" TC ")]).unwrap_err();
+        assert!(error.contains("already in use"));
+    }
+
+    #[test]
+    fn duplicate_aliases_are_rejected_with_full_unicode_case_folding() {
+        let error = validate_aliases(&[entry("straße"), entry("STRASSE")]).unwrap_err();
+        assert!(error.contains("already in use"));
+    }
+
+    #[test]
+    fn duplicate_aliases_are_rejected_across_unicode_normalization_forms() {
+        let error = validate_aliases(&[entry("café"), entry("cafe\u{301}")]).unwrap_err();
+        assert!(error.contains("already in use"));
+    }
+
+    #[test]
+    fn empty_alias_is_rejected() {
+        assert!(validate_aliases(&[entry("  ")]).is_err());
+    }
+}

--- a/ainto-core/src/config.rs
+++ b/ainto-core/src/config.rs
@@ -18,6 +18,12 @@ pub struct Config {
     /// Master switch for all AI-related features in the UI.
     /// When false, the launcher hides every AI surface.
     pub ai_enabled: bool,
+    /// Spotlight folders used by File Search. Empty values are ignored.
+    pub file_search_paths: Vec<String>,
+    /// Search the entire local Spotlight index instead of selected folders.
+    pub file_search_all_locations: bool,
+    /// Include hidden Spotlight results.
+    pub file_search_include_hidden: bool,
 }
 
 impl Default for Config {
@@ -28,6 +34,11 @@ impl Default for Config {
             claude_binary: "claude".to_string(),
             snippets_enabled: true,
             ai_enabled: true,
+            file_search_paths: dirs::home_dir()
+                .map(|path| vec![path.to_string_lossy().into_owned()])
+                .unwrap_or_default(),
+            file_search_all_locations: false,
+            file_search_include_hidden: false,
         }
     }
 }
@@ -68,4 +79,43 @@ impl Config {
 pub fn config_dir() -> Result<PathBuf, Error> {
     let home = dirs::home_dir().ok_or(Error::NoHomeDir)?;
     Ok(home.join(".config").join("ainto"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_config_receives_file_search_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+clipboard_max_items = 100
+clipboard_max_image_items = 25
+claude_binary = "claude"
+snippets_enabled = true
+ai_enabled = true
+"#,
+        )
+        .unwrap();
+
+        assert!(!config.file_search_all_locations);
+        assert!(!config.file_search_include_hidden);
+        assert_eq!(
+            config.file_search_paths,
+            Config::default().file_search_paths
+        );
+    }
+
+    #[test]
+    fn file_search_settings_round_trip() {
+        let config = Config {
+            file_search_paths: vec!["/Users/example/Documents".into()],
+            file_search_all_locations: true,
+            file_search_include_hidden: true,
+            ..Config::default()
+        };
+        let encoded = toml::to_string(&config).unwrap();
+        let decoded: Config = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded, config);
+    }
 }

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Mutex;
 
-use crate::{clipboard_store, config, discovery, search, snippets};
+use crate::{aliases, clipboard_store, config, discovery, search, snippets};
 
 // ============================================================
 // Global State
@@ -91,6 +91,7 @@ pub extern "C" fn rc_discover_apps(store_icons: bool) -> *const c_char {
                 "display_name": a.display_name,
                 "search_name": a.search_name,
                 "path": a.path,
+                "bundle_id": a.bundle_id,
                 "has_icon": a.icon_png.is_some(),
                 "ranking": a.ranking,
                 "is_favourite": a.is_favourite,
@@ -132,6 +133,7 @@ pub extern "C" fn rc_search_apps(query: *const c_char) -> *const c_char {
                     serde_json::json!({
                         "display_name": a.display_name,
                         "path": a.path,
+                        "bundle_id": a.bundle_id,
                         "ranking": a.ranking,
                         "is_favourite": a.is_favourite,
                     })
@@ -142,6 +144,29 @@ pub extern "C" fn rc_search_apps(query: *const c_char) -> *const c_char {
 
     let json = serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string());
     to_c_string(&json)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rc_get_all_apps() -> *const c_char {
+    let guard = APP_INDEX.lock().ok();
+    let results = guard
+        .as_ref()
+        .and_then(|opt| opt.as_ref())
+        .map(|idx| {
+            idx.apps()
+                .iter()
+                .map(|app| {
+                    serde_json::json!({
+                        "display_name": app.display_name,
+                        "path": app.path,
+                        "bundle_id": app.bundle_id,
+                        "ranking": app.ranking,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    to_c_string(&serde_json::to_string(&results).unwrap_or_else(|_| "[]".into()))
 }
 
 #[unsafe(no_mangle)]
@@ -157,6 +182,7 @@ pub extern "C" fn rc_get_top_apps(limit: u64) -> *const c_char {
                     serde_json::json!({
                         "display_name": a.display_name,
                         "path": a.path,
+                        "bundle_id": a.bundle_id,
                         "ranking": a.ranking,
                     })
                 })
@@ -178,7 +204,7 @@ pub extern "C" fn rc_increment_ranking(key: *const c_char) -> i32 {
     let score = crate::ranking::increment_and_save(&path, &k);
 
     // Also update in-memory AppIndex if it's an app path
-    if !k.starts_with("cmd:") {
+    if !k.starts_with("cmd:") && !k.starts_with("cmd-id:") {
         if let Ok(mut idx) = APP_INDEX.lock() {
             if let Some(ref mut index) = *idx {
                 index.update_ranking(&k);
@@ -284,8 +310,10 @@ pub extern "C" fn rc_clipboard_insert_text(
         .unwrap_or(-1)
 }
 
+/// # Safety
+/// `png_data` must point to at least `png_len` readable bytes for this call.
 #[unsafe(no_mangle)]
-pub extern "C" fn rc_clipboard_insert_image(
+pub unsafe extern "C" fn rc_clipboard_insert_image(
     png_data: *const u8,
     png_len: u64,
     width: u32,
@@ -493,6 +521,37 @@ pub extern "C" fn rc_snippet_expand(
     let clip = from_c_str(clipboard_text);
     let result = snippets::resolve_placeholders(&text, clip.as_deref());
     to_c_string(&result)
+}
+
+// ============================================================
+// Global Aliases
+// ============================================================
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rc_aliases_load() -> *const c_char {
+    let path = config::config_dir()
+        .map(|directory| directory.join("aliases.toml"))
+        .unwrap_or_default();
+    let entries = aliases::load_aliases(&path).unwrap_or_default();
+    to_c_string(&serde_json::to_string(&entries).unwrap_or_else(|_| "[]".into()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rc_aliases_save(json: *const c_char) -> i32 {
+    let Some(json_str) = from_c_str(json) else {
+        return -1;
+    };
+    let Ok(entries) = serde_json::from_str::<Vec<aliases::AliasEntry>>(&json_str) else {
+        return -1;
+    };
+    let path = match config::config_dir() {
+        Ok(directory) => directory.join("aliases.toml"),
+        Err(_) => return -1,
+    };
+    match aliases::save_aliases(&path, &entries) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
 }
 
 // ============================================================

--- a/ainto-core/src/lib.rs
+++ b/ainto-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate compiles to a static library (.a) linked into the Swift frontend via C ABI FFI.
 
 pub mod ai_commands;
+pub mod aliases;
 pub mod clipboard_store;
 pub mod claude;
 pub mod config;
@@ -38,4 +39,7 @@ pub enum Error {
 
     #[error("Claude spawn error: {0}")]
     ClaudeSpawn(String),
+
+    #[error("Invalid aliases: {0}")]
+    InvalidAliases(String),
 }

--- a/ainto-core/src/search.rs
+++ b/ainto-core/src/search.rs
@@ -18,6 +18,10 @@ pub struct AppIndex {
 }
 
 impl AppIndex {
+    pub fn apps(&self) -> &[AppEntry] {
+        &self.apps
+    }
+
     pub fn apps_mut(&mut self) -> &mut Vec<AppEntry> {
         &mut self.apps
     }


### PR DESCRIPTION
 > Depends on #5. This PR is intentionally stacked and should be reviewed
 after the dependency is merged.

   Add configurable, exact-match aliases for launcher targets without
 changing the original target behavior.

   What changed

   - Add global aliases for:
     - Applications
     - AI commands
     - Snippets
     - File Search
     - Clipboard History
     - System actions
   - Add an Aliases section to Settings.
   - Keep normal launcher search results visible when an alias matches.
   - Rank an exact alias match above regular fuzzy matches.
   - Reject empty and duplicate aliases.
   - Normalize aliases with Unicode-aware, case-insensitive matching.
   - Preserve unavailable targets in Settings so stale mappings can be
 removed or reassigned.
   - Reload aliases immediately after saving or when the aliases file
 changes.
   - Add stable IDs to AI commands so aliases survive command renames.
   - Migrate existing AI commands without IDs and persist generated IDs.
   - Preserve the last external application after editing aliases in
 Settings.
   - Ensure the launcher input field receives focus instead of an Alias
 Settings field.
   - Wait for asynchronous pasteboard updates when capturing selected text.

   Backward compatibility

   - Existing AI commands without IDs are assigned stable IDs when loaded.
   - Existing command names, prompts, icons, and behavior remain unchanged.
   - Users without an `aliases.toml` file continue with an empty alias list.
   - Alias mappings do not modify or replace the original launcher targets.

   Validation

   - `cargo test --release` — 24 tests passed
   - `swift test -c release` — 5 tests passed
   - Unsigned Xcode Release build succeeded
   - `git diff --check`