### PR TITLE
Enforce clippy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+
+      - name: Lint Rust core
+        run: cd ainto-core && cargo clippy --all-targets -- -D warnings
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '14.0'
 
       - name: Build Rust core
         run: cd ainto-core && cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          # Keep in sync with rust-toolchain.toml.
+          toolchain: '1.98.1'
           components: clippy
 
       - name: Lint Rust core

--- a/ainto-core/src/claude.rs
+++ b/ainto-core/src/claude.rs
@@ -130,7 +130,7 @@ impl ClaudeSession {
         // Read all stderr
         let stderr_text = if let Some(stderr) = self.child.stderr.take() {
             let reader = BufReader::new(stderr);
-            reader.lines().filter_map(|l| l.ok()).collect::<Vec<_>>().join("\n")
+            reader.lines().map_while(Result::ok).collect::<Vec<_>>().join("\n")
         } else {
             String::new()
         };

--- a/ainto-core/src/claude.rs
+++ b/ainto-core/src/claude.rs
@@ -105,10 +105,10 @@ impl ClaudeSession {
                 }
                 Ok(_) => {
                     // Try to extract session_id from init event
-                    if self.session_id.is_none() {
-                        if let Some(sid) = extract_session_id(&line) {
-                            self.session_id = Some(sid);
-                        }
+                    if self.session_id.is_none()
+                        && let Some(sid) = extract_session_id(&line)
+                    {
+                        self.session_id = Some(sid);
                     }
                     if let Some(text) = extract_text_from_stream_json(&line) {
                         self.response.push_str(&text);

--- a/ainto-core/src/clipboard_store.rs
+++ b/ainto-core/src/clipboard_store.rs
@@ -121,7 +121,7 @@ impl ClipboardStore {
         let (content_type, text, image_path) = match content {
             ClipboardContent::Text(t) => ("text", Some(t.clone()), None),
             ClipboardContent::Image { png_bytes, .. } => {
-                let fname = format!("{:016x}.png", hash);
+                let fname = format!("{hash:016x}.png");
                 let path = self.image_dir.join(&fname);
                 std::fs::write(&path, png_bytes)?;
                 ("image", None, Some(fname))
@@ -292,10 +292,7 @@ impl ClipboardStore {
     /// Evict oldest entries within a pool defined by a hardcoded WHERE clause.
     /// `where_clause` must be a literal — no user input is interpolated.
     fn evict_pool(&mut self, where_clause: &str, limit: usize) -> Result<(), Error> {
-        let count_sql = format!(
-            "SELECT COUNT(*) FROM clipboard_items WHERE {}",
-            where_clause
-        );
+        let count_sql = format!("SELECT COUNT(*) FROM clipboard_items WHERE {where_clause}");
         let count: i64 = self.db.query_row(&count_sql, [], |row| row.get(0))?;
 
         if count as usize <= limit {
@@ -305,8 +302,7 @@ impl ClipboardStore {
         let to_delete = count as usize - limit;
 
         let select_sql = format!(
-            "SELECT id, image_path FROM clipboard_items WHERE {} ORDER BY last_copied_at ASC LIMIT ?1",
-            where_clause
+            "SELECT id, image_path FROM clipboard_items WHERE {where_clause} ORDER BY last_copied_at ASC LIMIT ?1"
         );
         let mut stmt = self.db.prepare(&select_sql)?;
         let items: Vec<(i64, Option<String>)> = stmt

--- a/ainto-core/src/discovery.rs
+++ b/ainto-core/src/discovery.rs
@@ -342,10 +342,8 @@ pub fn icon_of_path(path: &str) -> Option<Vec<u8>> {
 
                 let (rep, out_w, out_h) = if let Some(rep) = best_rep {
                     (rep, target, target)
-                } else if let Some(rep) = largest_rep {
-                    (rep, largest_w, largest_h)
                 } else {
-                    return None;
+                    (largest_rep?, largest_w, largest_h)
                 };
 
                 let new_image = NSImage::imageWithSize_flipped_drawingHandler(

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -178,12 +178,11 @@ pub extern "C" fn rc_increment_ranking(key: *const c_char) -> i32 {
     let score = crate::ranking::increment_and_save(&path, &k);
 
     // Also update in-memory AppIndex if it's an app path
-    if !k.starts_with("cmd:") {
-        if let Ok(mut idx) = APP_INDEX.lock() {
-            if let Some(ref mut index) = *idx {
-                index.update_ranking(&k);
-            }
-        }
+    if !k.starts_with("cmd:")
+        && let Ok(mut idx) = APP_INDEX.lock()
+        && let Some(ref mut index) = *idx
+    {
+        index.update_ranking(&k);
     }
     score
 }
@@ -206,10 +205,10 @@ pub extern "C" fn rc_reset_rankings() -> i32 {
         return -1;
     }
 
-    if let Ok(mut idx) = APP_INDEX.lock() {
-        if let Some(ref mut index) = *idx {
-            index.apply_rankings(&std::collections::HashMap::new());
-        }
+    if let Ok(mut idx) = APP_INDEX.lock()
+        && let Some(ref mut index) = *idx
+    {
+        index.apply_rankings(&std::collections::HashMap::new());
     }
     0
 }
@@ -224,13 +223,13 @@ pub extern "C" fn rc_update_ranking(app_path: *const c_char) {
     let score = crate::ranking::increment_and_save(&path, &key);
 
     // Update in-memory AppIndex
-    if let Ok(mut idx) = APP_INDEX.lock() {
-        if let Some(ref mut index) = *idx {
-            index.update_ranking(&key);
-            // Set the ranking to the frecency score
-            if let Some(app) = index.apps_mut().iter_mut().find(|a| a.path == key) {
-                app.ranking = score;
-            }
+    if let Ok(mut idx) = APP_INDEX.lock()
+        && let Some(ref mut index) = *idx
+    {
+        index.update_ranking(&key);
+        // Set the ranking to the frecency score
+        if let Some(app) = index.apps_mut().iter_mut().find(|a| a.path == key) {
+            app.ranking = score;
         }
     }
 }

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -301,8 +301,13 @@ pub extern "C" fn rc_clipboard_insert_text(
         .unwrap_or(-1)
 }
 
+/// # Safety
+/// `png_data` must point to at least `png_len` readable bytes.
+///
+/// (The other entry points here are equally unsafe, but read their pointers
+/// through `from_c_str`, so clippy's heuristic does not flag them.)
 #[unsafe(no_mangle)]
-pub extern "C" fn rc_clipboard_insert_image(
+pub unsafe extern "C" fn rc_clipboard_insert_image(
     png_data: *const u8,
     png_len: u64,
     width: u32,

--- a/ainto-core/src/ranking.rs
+++ b/ainto-core/src/ranking.rs
@@ -17,7 +17,14 @@ pub struct RankingEntry {
     pub last_used: i64, // unix timestamp
 }
 
+impl Default for RankingEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RankingEntry {
+    /// A first use: one hit, right now.
     pub fn new() -> Self {
         Self {
             count: 1,
@@ -35,7 +42,7 @@ impl RankingEntry {
     /// Decays over time: full score within 1 day, drops to 0 after 20 days.
     pub fn frecency_score(&self) -> i32 {
         let days_since = (now() - self.last_used) as f64 / 86400.0;
-        let decay = (1.0 - days_since * 0.05).max(0.0).min(1.0);
+        let decay = (1.0 - days_since * 0.05).clamp(0.0, 1.0);
         let raw = (self.count as f64 * 10.0 * decay) as i32;
         raw.min(100) // cap at 100
     }
@@ -145,8 +152,8 @@ pub fn increment_and_save(path: &Path, key: &str) -> i32 {
     with_cache(path, |rankings| {
         let entry = rankings
             .entry(key.to_string())
-            .and_modify(|e| e.increment())
-            .or_insert_with(RankingEntry::new);
+            .and_modify(|entry| entry.increment())
+            .or_default();
         let score = entry.frecency_score();
         let _ = save_rankings(path, rankings);
         score

--- a/ainto-core/src/search.rs
+++ b/ainto-core/src/search.rs
@@ -47,14 +47,14 @@ impl AppIndex {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         scored.into_iter().map(|(app, _)| app).collect()
     }
 
     /// Get top-ranked apps (most frequently used).
     pub fn get_top_ranked(&self, limit: usize) -> Vec<&AppEntry> {
         let mut ranked: Vec<&AppEntry> = self.apps.iter().filter(|a| a.ranking > 0).collect();
-        ranked.sort_by(|a, b| b.ranking.cmp(&a.ranking));
+        ranked.sort_by_key(|app| std::cmp::Reverse(app.ranking));
         ranked.truncate(limit);
         ranked
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.1"
+profile = "minimal"
+components = ["clippy"]


### PR DESCRIPTION
CI builds and tests the Rust core but never lints it, so clippy findings only
surface when someone happens to run it locally.

Adds `cargo clippy --all-targets -- -D warnings` to the workflow, and fixes the
seven violations already on `main` so the gate passes on the same commit that
introduces it:

- `ranking.rs` — add the `Default` impl clippy asks for; use `clamp` instead of
  `max().min()`
- `clipboard_store.rs` — inline the three `format!` arguments
- `claude.rs` — `map_while(Result::ok)` instead of `filter_map`, which spins
  forever if the iterator keeps yielding `Err`
- `ffi.rs` — mark `rc_clipboard_insert_image` `unsafe`; it dereferences a
  caller-supplied pointer

The only behaviour change is the `claude.rs` one: a persistently failing stdout
read now ends the stream instead of looping.
