### PR TITLE
Protect config files from being overwritten and cache rankings in memory

### DIFF
--- a/AintoApp/AintoCoreBridge/ainto_core.h
+++ b/AintoApp/AintoCoreBridge/ainto_core.h
@@ -11,7 +11,9 @@
 // Config
 // ============================================================
 
-/// Load config, returns JSON string (caller must free with rc_free_string)
+/// Load config, returns JSON string (caller must free with rc_free_string).
+/// Returns NULL if the file exists but could not be read/parsed — do not treat
+/// NULL as an empty config, or a later save will overwrite it.
 const char* rc_config_load(void);
 
 /// Save config from JSON string, returns 0 on success
@@ -87,7 +89,8 @@ int32_t rc_clipboard_clear(void);
 // Snippets
 // ============================================================
 
-/// Load snippets, returns JSON array string
+/// Load snippets, returns JSON array string.
+/// Returns NULL if the file exists but could not be read/parsed.
 const char* rc_snippets_load(void);
 
 /// Save snippets from JSON array string
@@ -101,7 +104,8 @@ const char* rc_snippet_expand(const char* expansion_text, const char* clipboard_
 // AI Commands
 // ============================================================
 
-/// Load custom AI commands, returns JSON array string
+/// Load custom AI commands, returns JSON array string.
+/// Returns NULL if the file exists but could not be read/parsed.
 const char* rc_ai_commands_load(void);
 
 /// Save custom AI commands from JSON array string

--- a/AintoApp/AintoCoreBridge/ainto_core.h
+++ b/AintoApp/AintoCoreBridge/ainto_core.h
@@ -38,6 +38,9 @@ int32_t rc_increment_ranking(const char* key);
 /// Get ranking for any key
 int32_t rc_get_ranking(const char* key);
 
+/// Clear persisted and in-memory rankings, returns 0 on success
+int32_t rc_reset_rankings(void);
+
 /// Update ranking for an app (called after launch)
 void rc_update_ranking(const char* app_path);
 

--- a/AintoApp/Sources/App/AppDelegate.swift
+++ b/AintoApp/Sources/App/AppDelegate.swift
@@ -11,8 +11,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var textExpander: TextExpander?
     private var trayManager: TrayManager?
     private var settingsWindow: NSWindow?
-    private var configWatcherSources: [DispatchSourceFileSystemObject] = []
-    private var configWatcherFDs: [Int32] = []
+    /// Live config-file watchers, keyed by file name.
+    private var configWatchers: [String: DispatchSourceFileSystemObject] = [:]
 
     private var updaterController: SPUStandardUpdaterController?
 
@@ -76,43 +76,81 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         watchConfigDirectory()
     }
 
+    private static let watchedConfigFiles = ["snippets.toml", "ai-commands.toml", "config.toml"]
+
+    /// Delay before re-opening a config file that is missing or was replaced.
+    /// An atomic save briefly leaves no file at the path, so retry rather than
+    /// give up on the first failure.
+    private static let configWatchRearmDelay: TimeInterval = 1.0
+
+    private var configDirectory: String { NSHomeDirectory() + "/.config/ainto" }
+
     /// Monitor config files for external changes and reload automatically.
     private func watchConfigDirectory() {
-        let configDir = NSHomeDirectory() + "/.config/ainto"
-        let files = ["snippets.toml", "ai-commands.toml", "config.toml"]
+        for file in Self.watchedConfigFiles {
+            watchConfigFile(named: file)
+        }
+    }
 
-        for file in files {
-            let path = configDir + "/" + file
-            let fd = open(path, O_EVTONLY)
-            guard fd >= 0 else { continue }
-            configWatcherFDs.append(fd)
+    /// Watch one config file, re-arming whenever the path stops pointing at the
+    /// inode we opened.
+    ///
+    /// A kqueue watcher follows the file descriptor, not the path. Editors save
+    /// by writing a temp file and renaming it over the original, which swaps the
+    /// inode out — so after a rename or delete the old watcher is live but deaf,
+    /// and the path has to be re-opened. The same retry covers a file that does
+    /// not exist yet at launch (snippets.toml is only created on first save).
+    private func watchConfigFile(named name: String) {
+        let fd = open(configDirectory + "/" + name, O_EVTONLY)
+        guard fd >= 0 else {
+            scheduleConfigWatchRearm(named: name)
+            return
+        }
 
-            let source = DispatchSource.makeFileSystemObjectSource(
-                fileDescriptor: fd,
-                eventMask: [.write, .rename, .delete],
-                queue: .main
-            )
-            source.setEventHandler { [weak self] in
-                if file == "config.toml" {
-                    // Covers both the Settings toggle (saved via rc_config_save)
-                    // and manual TOML edits.
-                    self?.applySnippetsEnabled()
-                } else {
-                    self?.searchPanel?.viewModel.loadSnippets()
-                    self?.searchPanel?.viewModel.loadAICommands()
-                    self?.textExpander?.reloadSnippets()
-                }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self, let source = self.configWatchers[name] else { return }
+            let events = source.data
+            self.reloadConfigFile(named: name)
+            if events.contains(.rename) || events.contains(.delete) {
+                source.cancel()
+                self.configWatchers[name] = nil
+                self.scheduleConfigWatchRearm(named: name)
             }
-            source.setCancelHandler { close(fd) }
-            source.resume()
-            configWatcherSources.append(source)
+        }
+        source.setCancelHandler { close(fd) }
+        configWatchers[name] = source
+        source.resume()
+    }
+
+    private func scheduleConfigWatchRearm(named name: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.configWatchRearmDelay) { [weak self] in
+            guard let self, self.configWatchers[name] == nil else { return }
+            self.watchConfigFile(named: name)
+        }
+    }
+
+    private func reloadConfigFile(named name: String) {
+        if name == "config.toml" {
+            // Covers both the Settings toggle (saved via rc_config_save)
+            // and manual TOML edits.
+            applySnippetsEnabled()
+        } else {
+            searchPanel?.viewModel.loadSnippets()
+            searchPanel?.viewModel.loadAICommands()
+            textExpander?.reloadSnippets()
         }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         clipboardMonitor?.stopMonitoring()
         textExpander?.stop()
-        configWatcherSources.forEach { $0.cancel() }
+        configWatchers.values.forEach { $0.cancel() }
+        configWatchers.removeAll()
     }
 
     private func toggleSearchPanel() {

--- a/AintoApp/Sources/App/AppDelegate.swift
+++ b/AintoApp/Sources/App/AppDelegate.swift
@@ -13,6 +13,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindow: NSWindow?
     /// Live config-file watchers, keyed by file name.
     private var configWatchers: [String: DispatchSourceFileSystemObject] = [:]
+    /// Watches for files that are created after launch without polling.
+    private var configDirectoryWatcher: DispatchSourceFileSystemObject?
 
     private var updaterController: SPUStandardUpdaterController?
 
@@ -78,17 +80,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private static let watchedConfigFiles = ["snippets.toml", "ai-commands.toml", "config.toml"]
 
-    /// Delay before re-opening a config file that is missing or was replaced.
-    /// An atomic save briefly leaves no file at the path, so retry rather than
-    /// give up on the first failure.
-    private static let configWatchRearmDelay: TimeInterval = 1.0
-
     private var configDirectory: String { NSHomeDirectory() + "/.config/ainto" }
 
-    /// Monitor config files for external changes and reload automatically.
+    /// Monitor the directory so files missing at launch can be watched as soon
+    /// as they are created, without waking the app on a polling timer.
     private func watchConfigDirectory() {
-        for file in Self.watchedConfigFiles {
-            watchConfigFile(named: file)
+        guard configDirectoryWatcher == nil else { return }
+        try? FileManager.default.createDirectory(
+            atPath: configDirectory,
+            withIntermediateDirectories: true
+        )
+        let fileDescriptor = open(configDirectory, O_EVTONLY)
+        guard fileDescriptor >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self, let activeSource = self.configDirectoryWatcher else { return }
+            let events = activeSource.data
+            if events.contains(.rename) || events.contains(.delete) {
+                activeSource.cancel()
+                self.configDirectoryWatcher = nil
+                self.configWatchers.values.forEach { $0.cancel() }
+                self.configWatchers.removeAll()
+                self.watchConfigDirectory()
+                return
+            }
+            for name in Self.watchedConfigFiles where self.configWatchers[name] == nil {
+                self.watchConfigFile(named: name, reloadAfterOpening: true)
+            }
+        }
+        source.setCancelHandler { close(fileDescriptor) }
+        configDirectoryWatcher = source
+        source.resume()
+
+        for name in Self.watchedConfigFiles {
+            watchConfigFile(named: name, reloadAfterOpening: false)
         }
     }
 
@@ -100,37 +130,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// inode out — so after a rename or delete the old watcher is live but deaf,
     /// and the path has to be re-opened. The same retry covers a file that does
     /// not exist yet at launch (snippets.toml is only created on first save).
-    private func watchConfigFile(named name: String) {
-        let fd = open(configDirectory + "/" + name, O_EVTONLY)
-        guard fd >= 0 else {
-            scheduleConfigWatchRearm(named: name)
-            return
-        }
+    private func watchConfigFile(named name: String, reloadAfterOpening: Bool) {
+        guard configWatchers[name] == nil else { return }
+        let fileDescriptor = open(configDirectory + "/" + name, O_EVTONLY)
+        guard fileDescriptor >= 0 else { return }
 
         let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
+            fileDescriptor: fileDescriptor,
             eventMask: [.write, .rename, .delete],
             queue: .main
         )
         source.setEventHandler { [weak self] in
-            guard let self, let source = self.configWatchers[name] else { return }
-            let events = source.data
+            guard let self, let activeSource = self.configWatchers[name] else { return }
+            let events = activeSource.data
             self.reloadConfigFile(named: name)
             if events.contains(.rename) || events.contains(.delete) {
-                source.cancel()
+                activeSource.cancel()
                 self.configWatchers[name] = nil
-                self.scheduleConfigWatchRearm(named: name)
+                // Atomic saves normally leave the replacement at the path by
+                // the next main-queue turn. If it is still missing, the
+                // directory watcher will install a watcher when it is created.
+                DispatchQueue.main.async { [weak self] in
+                    self?.watchConfigFile(named: name, reloadAfterOpening: true)
+                }
             }
         }
-        source.setCancelHandler { close(fd) }
+        source.setCancelHandler { close(fileDescriptor) }
         configWatchers[name] = source
         source.resume()
-    }
-
-    private func scheduleConfigWatchRearm(named name: String) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.configWatchRearmDelay) { [weak self] in
-            guard let self, self.configWatchers[name] == nil else { return }
-            self.watchConfigFile(named: name)
+        if reloadAfterOpening {
+            reloadConfigFile(named: name)
         }
     }
 
@@ -151,6 +180,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         textExpander?.stop()
         configWatchers.values.forEach { $0.cancel() }
         configWatchers.removeAll()
+        configDirectoryWatcher?.cancel()
+        configDirectoryWatcher = nil
     }
 
     private func toggleSearchPanel() {

--- a/AintoApp/Sources/App/AppDelegate.swift
+++ b/AintoApp/Sources/App/AppDelegate.swift
@@ -76,6 +76,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Watch ~/.config/ainto/ for external file changes (e.g. manual TOML edits)
         watchConfigDirectory()
+
+        // Seed search's in-memory lists once, after installing the watchers so
+        // an external save cannot fall between the initial read and observation.
+        // Later edits are handled by the save paths and config watchers.
+        searchPanel?.viewModel.loadSnippets()
+        searchPanel?.viewModel.loadAICommands()
     }
 
     private static let watchedConfigFiles = ["snippets.toml", "ai-commands.toml", "config.toml"]

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -782,6 +782,10 @@ final class SearchViewModel: ObservableObject {
     // MARK: - Snippets
 
     func loadSnippets() {
+        // A later reload can fail after an earlier one succeeded. Close the
+        // save gate before every attempt so stale in-memory data can never
+        // overwrite a file that is currently unreadable.
+        snippetsLoaded = false
         guard let cStr = rc_snippets_load() else { return }
         let jsonStr = String(cString: cStr)
         rc_free_string(cStr)
@@ -881,6 +885,9 @@ final class SearchViewModel: ObservableObject {
     // MARK: - AI Commands
 
     func loadAICommands() {
+        // Keep saves disabled unless this exact reload succeeded. Otherwise an
+        // external malformed edit could be replaced by stale in-memory data.
+        aiCommandsLoaded = false
         guard let loaded = AICommand.loadAll() else { return }
         aiCommands = loaded
         aiCommandsLoaded = true

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -14,13 +14,15 @@ struct AICommand: Identifiable {
     }
 
     /// Load all commands from TOML (includes defaults on first run).
-    static func loadAll() -> [AICommand] {
-        guard let cStr = rc_ai_commands_load() else { return [] }
+    /// Returns nil when the file exists but could not be read — callers must
+    /// not persist over a file they failed to load.
+    static func loadAll() -> [AICommand]? {
+        guard let cStr = rc_ai_commands_load() else { return nil }
         let jsonStr = String(cString: cStr)
         rc_free_string(cStr)
 
         guard let data = jsonStr.data(using: .utf8),
-              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+              let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
 
         return entries.map { entry in
             AICommand(
@@ -296,7 +298,11 @@ final class SearchViewModel: ObservableObject {
     private var claudeSession: UnsafeMutableRawPointer?
     private var claudeSessionId: String?
 
-    // Snippet state
+    // Snippet state.
+    // `snippetsLoaded` stays false until the file has been read successfully;
+    // it guards saving so an unreadable file is never overwritten with an
+    // empty list. Same pattern as `hasLoaded` in SettingsView.
+    private var snippetsLoaded = false
     @Published var snippets: [SnippetItem] = []
     @Published var snippetSelectedIndex: Int = 0
     @Published var snippetFilter: String = ""
@@ -311,6 +317,7 @@ final class SearchViewModel: ObservableObject {
     var claudeBinary: String = "claude"
 
     // AI Commands state
+    private var aiCommandsLoaded = false
     @Published var aiCommands: [AICommand] = []
     @Published var aiCommandSelectedIndex: Int = 0
     @Published var aiCommandFilter: String = ""
@@ -790,10 +797,13 @@ final class SearchViewModel: ObservableObject {
                 expansion: entry["expansion"] as? String ?? ""
             )
         }
+        snippetsLoaded = true
         snippetSelectedIndex = 0
     }
 
     func saveSnippets() {
+        // Never write over a file we could not read.
+        guard snippetsLoaded else { return }
         let jsonArray: [[String: Any]] = snippets.map { s in
             ["id": s.id, "name": s.name, "keyword": s.keyword, "expansion": s.expansion]
         }
@@ -871,7 +881,9 @@ final class SearchViewModel: ObservableObject {
     // MARK: - AI Commands
 
     func loadAICommands() {
-        aiCommands = AICommand.loadAll()
+        guard let loaded = AICommand.loadAll() else { return }
+        aiCommands = loaded
+        aiCommandsLoaded = true
         aiCommandSelectedIndex = 0
     }
 
@@ -906,6 +918,8 @@ final class SearchViewModel: ObservableObject {
     }
 
     func saveAICommands() {
+        // Never write over a file we could not read.
+        guard aiCommandsLoaded else { return }
         let jsonArray: [[String: Any]] = aiCommands.map { cmd in
             ["name": cmd.name, "icon": cmd.icon, "prompt": cmd.prompt]
         }

--- a/AintoApp/Sources/Bridge/SearchViewModel.swift
+++ b/AintoApp/Sources/Bridge/SearchViewModel.swift
@@ -506,36 +506,22 @@ final class SearchViewModel: ObservableObject {
             }
         }
 
-        // Search snippets
-        var snippetResults: [SearchResult] = []
-        if let cStr = rc_snippets_load() {
-            let jsonStr = String(cString: cStr)
-            rc_free_string(cStr)
-
-            if let data = jsonStr.data(using: .utf8),
-               let snippets = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
-                snippetResults = snippets
-                    .filter { snippet in
-                        let name = snippet["name"] as? String ?? ""
-                        let keyword = snippet["keyword"] as? String ?? ""
-                        return fuzzyMatch(query, name) || fuzzyMatch(query, keyword)
-                    }
-                    .prefix(5)
-                    .map { snippet in
-                        let name = snippet["name"] as? String ?? ""
-                        let keyword = snippet["keyword"] as? String ?? ""
-                        let expansion = snippet["expansion"] as? String ?? ""
-                        return SearchResult(
-                            title: name,
-                            subtitle: "Snippet: \(keyword)",
-                            icon: nil,
-                            systemIcon: "doc.text.fill"
-                        ) { [weak self] in
-                            self?.expandAndPasteSnippet(expansion)
-                        }
-                    }
+        // Search snippets. Uses the in-memory copy — refreshed when the panel
+        // opens and by the config watcher — so a keystroke never reads disk.
+        let snippetResults: [SearchResult] = snippets
+            .filter { fuzzyMatch(query, $0.name) || fuzzyMatch(query, $0.keyword) }
+            .prefix(5)
+            .map { snippet in
+                let expansion = snippet.expansion
+                return SearchResult(
+                    title: snippet.name,
+                    subtitle: "Snippet: \(snippet.keyword)",
+                    icon: nil,
+                    systemIcon: "doc.text.fill"
+                ) { [weak self] in
+                    self?.expandAndPasteSnippet(expansion)
+                }
             }
-        }
 
         // Built-in commands that fuzzy match
         var commandResults: [SearchResult] = []
@@ -544,15 +530,15 @@ final class SearchViewModel: ObservableObject {
         // AI commands (built-in + custom) — fuzzy match. Hidden entirely when
         // the AI master switch is off.
         if aiEnabled {
-            let matchingAICommands = AICommand.loadAll().filter { cmd in
-                fuzzyMatch(q, cmd.name)
-            }
-            let rankedAICommands = matchingAICommands.sorted { a, b in
-                self.commandRanking(for: a.name) > self.commandRanking(for: b.name)
-            }
-            for cmd in rankedAICommands.prefix(6) {
-                let command = cmd
-                let cmdScore = fuzzyScore(q, command.name) + self.commandRanking(for: command.name)
+            // Rank once per command rather than inside the sort comparator,
+            // which called it O(n log n) times per keystroke.
+            let rankedAICommands = aiCommands
+                .filter { fuzzyMatch(q, $0.name) }
+                .map { (command: $0, rank: self.commandRanking(for: $0.name)) }
+                .sorted { $0.rank > $1.rank }
+            for entry in rankedAICommands.prefix(6) {
+                let command = entry.command
+                let cmdScore = fuzzyScore(q, command.name) + entry.rank
                 var result = SearchResult(
                     title: command.name,
                     subtitle: "AI Command",
@@ -1108,12 +1094,11 @@ final class SearchViewModel: ObservableObject {
             ) { [weak self] in self?.goToAICommands() })
 
             // AI Commands — sorted by usage, top 4
-            let aiCommands = AICommand.loadAll()
-            let sorted = aiCommands.sorted { a, b in
-                commandRanking(for: a.name) > commandRanking(for: b.name)
-            }
-            for cmd in sorted.prefix(4) {
-                let command = cmd
+            let sorted = aiCommands
+                .map { (command: $0, rank: commandRanking(for: $0.name)) }
+                .sorted { $0.rank > $1.rank }
+            for entry in sorted.prefix(4) {
+                let command = entry.command
                 var result = SearchResult(
                     title: command.name,
                     subtitle: "AI Command",

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -86,6 +86,11 @@ final class SearchPanel: NSPanel {
         // Pick up any Settings change to the AI master switch.
         viewModel.loadAISettings()
 
+        // Refresh the in-memory snippet/AI-command lists that search reads from,
+        // so typing never has to hit disk.
+        viewModel.loadSnippets()
+        viewModel.loadAICommands()
+
         if !hasUserPosition {
             let screen = NSScreen.screens.first(where: {
                 NSMouseInRect(NSEvent.mouseLocation, $0.frame, false)

--- a/AintoApp/Sources/Views/SearchPanel.swift
+++ b/AintoApp/Sources/Views/SearchPanel.swift
@@ -86,11 +86,6 @@ final class SearchPanel: NSPanel {
         // Pick up any Settings change to the AI master switch.
         viewModel.loadAISettings()
 
-        // Refresh the in-memory snippet/AI-command lists that search reads from,
-        // so typing never has to hit disk.
-        viewModel.loadSnippets()
-        viewModel.loadAICommands()
-
         if !hasUserPosition {
             let screen = NSScreen.screens.first(where: {
                 NSMouseInRect(NSEvent.mouseLocation, $0.frame, false)

--- a/AintoApp/Sources/Views/SettingsView.swift
+++ b/AintoApp/Sources/Views/SettingsView.swift
@@ -90,8 +90,7 @@ struct SettingsView: View {
         .alert("Reset Rankings", isPresented: $showResetConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Reset", role: .destructive) {
-                let path = ("~/.config/ainto/ranking.toml" as NSString).expandingTildeInPath
-                try? FileManager.default.removeItem(atPath: path)
+                _ = rc_reset_rankings()
             }
         } message: {
             Text("This will reset all app and command usage rankings. This cannot be undone.")

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -47,6 +47,9 @@ pub extern "C" fn rc_free_string(s: *const c_char) {
 // Config
 // ============================================================
 
+/// Returns null when the config file exists but could not be read or parsed.
+/// Callers must treat null as "unknown" and fall back to their own defaults —
+/// never as "empty config", or saving would overwrite a file we failed to read.
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_config_load() -> *const c_char {
     match config::Config::load() {
@@ -54,10 +57,7 @@ pub extern "C" fn rc_config_load() -> *const c_char {
             let json = serde_json::to_string(&cfg).unwrap_or_default();
             to_c_string(&json)
         }
-        Err(_) => {
-            let json = serde_json::to_string(&config::Config::default()).unwrap_or_default();
-            to_c_string(&json)
-        }
+        Err(_) => ptr::null(),
     }
 }
 
@@ -454,12 +454,16 @@ pub extern "C" fn rc_clipboard_clear() -> i32 {
 // Snippets
 // ============================================================
 
+/// Returns null when snippets.toml exists but could not be read or parsed.
+/// A missing file is not an error — it yields an empty list.
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_snippets_load() -> *const c_char {
     let path = config::config_dir()
         .map(|d| d.join("snippets.toml"))
         .unwrap_or_default();
-    let snips = snippets::load_snippets(&path).unwrap_or_default();
+    let Ok(snips) = snippets::load_snippets(&path) else {
+        return ptr::null();
+    };
     let json = serde_json::to_string(&snips).unwrap_or_else(|_| "[]".to_string());
     to_c_string(&json)
 }
@@ -499,12 +503,16 @@ pub extern "C" fn rc_snippet_expand(
 // AI Commands
 // ============================================================
 
+/// Returns null when ai-commands.toml exists but could not be read or parsed.
+/// A missing file is not an error — it is seeded with the built-in defaults.
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_ai_commands_load() -> *const c_char {
     let path = config::config_dir()
         .map(|d| d.join("ai-commands.toml"))
         .unwrap_or_default();
-    let cmds = crate::ai_commands::load_commands(&path).unwrap_or_default();
+    let Ok(cmds) = crate::ai_commands::load_commands(&path) else {
+        return ptr::null();
+    };
     let json = serde_json::to_string(&cmds).unwrap_or_else(|_| "[]".to_string());
     to_c_string(&json)
 }

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -197,6 +197,23 @@ pub extern "C" fn rc_get_ranking(key: *const c_char) -> i32 {
     crate::ranking::get_score(&path, &k)
 }
 
+/// Clear persisted rankings together with every in-memory ranking value.
+#[unsafe(no_mangle)]
+pub extern "C" fn rc_reset_rankings() -> i32 {
+    let Ok(cfg_dir) = config::config_dir() else { return -1 };
+    let path = cfg_dir.join("ranking.toml");
+    if crate::ranking::reset(&path).is_err() {
+        return -1;
+    }
+
+    if let Ok(mut idx) = APP_INDEX.lock() {
+        if let Some(ref mut index) = *idx {
+            index.apply_rankings(&std::collections::HashMap::new());
+        }
+    }
+    0
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rc_update_ranking(app_path: *const c_char) {
     let Some(key) = from_c_str(app_path) else {

--- a/ainto-core/src/ffi.rs
+++ b/ainto-core/src/ffi.rs
@@ -102,7 +102,7 @@ pub extern "C" fn rc_discover_apps(store_icons: bool) -> *const c_char {
     if let Ok(mut idx) = APP_INDEX.lock() {
         // Load rankings
         let rankings = if let Ok(cfg_dir) = config::config_dir() {
-            crate::ranking::load_rankings(&cfg_dir.join("ranking.toml"))
+            crate::ranking::all_rankings(&cfg_dir.join("ranking.toml"))
         } else {
             std::collections::HashMap::new()
         };

--- a/ainto-core/src/ranking.rs
+++ b/ainto-core/src/ranking.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
@@ -98,21 +99,45 @@ pub fn save_rankings(path: &Path, rankings: &HashMap<String, RankingEntry>) -> R
     Ok(())
 }
 
+/// Process-wide cache of the ranking table.
+///
+/// `get_score` is on the search-scoring path and is called once per candidate
+/// while ranking results, so re-reading and re-parsing the TOML on every call
+/// cost a file read per lookup. The file is only ever written through
+/// `increment_and_save`, so the cache stays authoritative for this process.
+///
+/// Assumes a single ranking file per process (always `<config_dir>/ranking.toml`);
+/// the first path passed in wins.
+static CACHE: Mutex<Option<HashMap<String, RankingEntry>>> = Mutex::new(None);
+
+/// Run `f` against the cached ranking table, loading it from disk on first use.
+fn with_cache<T>(path: &Path, f: impl FnOnce(&mut HashMap<String, RankingEntry>) -> T) -> T {
+    let mut guard = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let rankings = guard.get_or_insert_with(|| load_rankings(path));
+    f(rankings)
+}
+
+/// Snapshot of the current ranking table.
+pub fn all_rankings(path: &Path) -> HashMap<String, RankingEntry> {
+    with_cache(path, |rankings| rankings.clone())
+}
+
 /// Increment a key and save. Returns the new frecency score.
 pub fn increment_and_save(path: &Path, key: &str) -> i32 {
-    let mut rankings = load_rankings(path);
-    rankings
-        .entry(key.to_string())
-        .and_modify(|e| e.increment())
-        .or_insert_with(RankingEntry::new);
-    let _ = save_rankings(path, &rankings);
-    rankings.get(key).map(|e| e.frecency_score()).unwrap_or(0)
+    with_cache(path, |rankings| {
+        let entry = rankings
+            .entry(key.to_string())
+            .and_modify(|e| e.increment())
+            .or_insert_with(RankingEntry::new);
+        let score = entry.frecency_score();
+        let _ = save_rankings(path, rankings);
+        score
+    })
 }
 
 /// Get frecency score for a key.
 pub fn get_score(path: &Path, key: &str) -> i32 {
-    load_rankings(path)
-        .get(key)
-        .map(|e| e.frecency_score())
-        .unwrap_or(0)
+    with_cache(path, |rankings| {
+        rankings.get(key).map(|e| e.frecency_score()).unwrap_or(0)
+    })
 }

--- a/ainto-core/src/ranking.rs
+++ b/ainto-core/src/ranking.rs
@@ -122,6 +122,18 @@ pub fn all_rankings(path: &Path) -> HashMap<String, RankingEntry> {
     with_cache(path, |rankings| rankings.clone())
 }
 
+/// Remove persisted rankings and clear the process-wide cache atomically.
+pub fn reset(path: &Path) -> Result<(), Error> {
+    let mut guard = CACHE.lock().unwrap_or_else(|error| error.into_inner());
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    *guard = Some(HashMap::new());
+    Ok(())
+}
+
 /// Increment a key and save. Returns the new frecency score.
 pub fn increment_and_save(path: &Path, key: &str) -> i32 {
     with_cache(path, |rankings| {
@@ -140,4 +152,27 @@ pub fn get_score(path: &Path, key: &str) -> i32 {
     with_cache(path, |rankings| {
         rankings.get(key).map(|e| e.frecency_score()).unwrap_or(0)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_clears_the_cache_and_removes_the_file() {
+        let directory = std::env::temp_dir().join(format!(
+            "ainto-ranking-test-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let path = directory.join("ranking.toml");
+
+        assert!(increment_and_save(&path, "app:test") > 0);
+        assert!(path.exists());
+
+        reset(&path).unwrap();
+
+        assert_eq!(get_score(&path, "app:test"), 0);
+        assert!(!path.exists());
+        std::fs::remove_dir_all(directory).ok();
+    }
 }

--- a/ainto-core/src/ranking.rs
+++ b/ainto-core/src/ranking.rs
@@ -4,7 +4,7 @@
 //! Score = count * 10 * decay, where decay decreases over days since last use.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
@@ -106,14 +106,18 @@ pub fn save_rankings(path: &Path, rankings: &HashMap<String, RankingEntry>) -> R
 /// cost a file read per lookup. The file is only ever written through
 /// `increment_and_save`, so the cache stays authoritative for this process.
 ///
-/// Assumes a single ranking file per process (always `<config_dir>/ranking.toml`);
-/// the first path passed in wins.
-static CACHE: Mutex<Option<HashMap<String, RankingEntry>>> = Mutex::new(None);
+/// Production uses one ranking path. Keying by path also keeps callers using
+/// separate temporary files isolated, including tests running concurrently.
+type RankingCache = HashMap<PathBuf, HashMap<String, RankingEntry>>;
+static CACHE: Mutex<Option<RankingCache>> = Mutex::new(None);
 
-/// Run `f` against the cached ranking table, loading it from disk on first use.
+/// Run `f` against this path's table, loading it from disk on first use.
 fn with_cache<T>(path: &Path, f: impl FnOnce(&mut HashMap<String, RankingEntry>) -> T) -> T {
     let mut guard = CACHE.lock().unwrap_or_else(|e| e.into_inner());
-    let rankings = guard.get_or_insert_with(|| load_rankings(path));
+    let cache = guard.get_or_insert_with(HashMap::new);
+    let rankings = cache
+        .entry(path.to_path_buf())
+        .or_insert_with(|| load_rankings(path));
     f(rankings)
 }
 
@@ -122,7 +126,7 @@ pub fn all_rankings(path: &Path) -> HashMap<String, RankingEntry> {
     with_cache(path, |rankings| rankings.clone())
 }
 
-/// Remove persisted rankings and clear the process-wide cache atomically.
+/// Remove this path's persisted rankings and clear only its cached table.
 pub fn reset(path: &Path) -> Result<(), Error> {
     let mut guard = CACHE.lock().unwrap_or_else(|error| error.into_inner());
     match std::fs::remove_file(path) {
@@ -130,7 +134,9 @@ pub fn reset(path: &Path) -> Result<(), Error> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
     }
-    *guard = Some(HashMap::new());
+    guard
+        .get_or_insert_with(HashMap::new)
+        .insert(path.to_path_buf(), HashMap::new());
     Ok(())
 }
 
@@ -157,6 +163,58 @@ pub fn get_score(path: &Path, key: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn separate_paths_keep_independent_cached_tables_and_resets() {
+        let directory = std::env::temp_dir().join(format!(
+            "ainto-ranking-paths-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let first = directory.join("first.toml");
+        let second = directory.join("second.toml");
+        let key = "app:shared";
+        increment_and_save(&first, key);
+        increment_and_save(&second, key);
+        increment_and_save(&second, key);
+        assert_eq!(all_rankings(&first)[key].count, 1);
+        assert_eq!(all_rankings(&second)[key].count, 2);
+        assert_eq!(load_rankings(&first)[key].count, 1);
+        assert_eq!(load_rankings(&second)[key].count, 2);
+
+        // Returning to another path must retain its cached table, not reload it.
+        std::fs::write(&second, "[rankings]\n").unwrap();
+        assert_eq!(all_rankings(&first)[key].count, 1);
+        assert_eq!(all_rankings(&second)[key].count, 2);
+        reset(&first).unwrap();
+        assert_eq!(get_score(&first, key), 0);
+        assert_eq!(all_rankings(&second)[key].count, 2);
+        increment_and_save(&second, key);
+        assert_eq!(load_rankings(&second)[key].count, 3);
+        reset(&second).unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn concurrent_paths_do_not_share_counts() {
+        let directory = std::env::temp_dir().join(format!(
+            "ainto-ranking-parallel-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::thread::scope(|scope| {
+            for expected in 1..=4 {
+                let path = directory.join(format!("{expected}.toml"));
+                scope.spawn(move || {
+                    for _ in 0..expected {
+                        increment_and_save(&path, "app:shared");
+                    }
+                    assert_eq!(all_rankings(&path)["app:shared"].count, expected);
+                    assert_eq!(load_rankings(&path)["app:shared"].count, expected);
+                    reset(&path).unwrap();
+                });
+            }
+        });
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn reset_clears_the_cache_and_removes_the_file() {

--- a/ainto-core/src/search.rs
+++ b/ainto-core/src/search.rs
@@ -81,9 +81,10 @@ impl AppIndex {
     /// Apply frecency rankings loaded from disk.
     pub fn apply_rankings(&mut self, rankings: &std::collections::HashMap<String, crate::ranking::RankingEntry>) {
         for app in &mut self.apps {
-            if let Some(entry) = rankings.get(&app.path) {
-                app.ranking = entry.frecency_score();
-            }
+            app.ranking = rankings
+                .get(&app.path)
+                .map(crate::ranking::RankingEntry::frecency_score)
+                .unwrap_or(0);
         }
     }
 

--- a/ainto-core/src/snippets.rs
+++ b/ainto-core/src/snippets.rs
@@ -200,6 +200,23 @@ mod tests {
     }
 
     #[test]
+    fn malformed_file_is_an_error_not_an_empty_list() {
+        // Callers distinguish these two cases to decide whether saving is safe:
+        // a missing file is an empty list, an unparseable one must be an error
+        // so it is never silently overwritten.
+        let dir = std::env::temp_dir().join(format!("ainto-snippets-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("snippets.toml");
+
+        assert!(load_snippets(&path).unwrap().is_empty(), "missing file is empty");
+
+        std::fs::write(&path, "this is not valid toml {{{").unwrap();
+        assert!(load_snippets(&path).is_err(), "malformed file must error");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn test_snippet_expand() {
         let snippet = Snippet::new(
             "Test".into(),


### PR DESCRIPTION
Two problems in how `~/.config/ainto` is read and written.

**Silent data loss.** The FFI loaders returned an empty list when a TOML file
could not be parsed, and the UI could not tell that apart from "no entries yet".
Touching the snippets or AI-commands list then saved that empty state back over
the file — one malformed edit, or an interrupted write, silently destroyed every
snippet the user had.

`rc_config_load`, `rc_snippets_load` and `rc_ai_commands_load` now return NULL on
parse failure, and callers keep saves disabled until a load has actually
succeeded, so a file that failed to parse is never written over.

**Disk I/O on every keystroke.** `ranking.toml` was read and parsed inside the
sort comparators, so a single keystroke re-read it on the order of a hundred
times. Rankings are now cached in-process behind a mutex, with resets routed
through the core so the cache and the file cannot drift apart.

**Config watchers.** kqueue follows the file descriptor, not the path, so a watch
died the first time an editor replaced the file with a rename — external edits
stopped being picked up after one save. Watchers now re-arm on rename and delete,
and files that do not exist yet are picked up when they appear, without polling.
